### PR TITLE
.vscode: enable gofumpt formatting for gopls.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "go.useLanguageServer": true,
+    "gopls": {
+        "formatting.gofumpt": true,
+    },
+}


### PR DESCRIPTION
I'm not sure what version of gofumpt this is using, though. For example, if I
type this into a file and save:

    func foo() {
        f :=
            1
        _ = f
    }

... it doesn't move the 1 to the same line as "f :=". But if I run `make
gofumpt` which invokes gofumpt, it does.