### PR TITLE
Add a make target for running `protoc`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,17 @@ include tools.mk
 
 build_files := $(shell git ls-files -- 'WORKSPACE' '**/BUILD.bazel' '*.bzl')
 go_files := $(shell git ls-files -- '*.go')
+proto_files := $(shell git ls-files -- '*.proto')
+
+.PHONY: generate
+generate: protoc
+
+.PHONY: protoc
+protoc: \
+	$(proto_files) \
+	$(protoc)
+protoc:
+	$(protoc) --version
 
 .PHONY: fix
 fix: buildifier gofumpt

--- a/tools.mk
+++ b/tools.mk
@@ -31,3 +31,22 @@ $(gofumpt): go.mod
 		build \
 		-o='$@' \
 		mvdan.cc/gofumpt
+
+# protoc: the protobuf compiler.
+protoc_version := 3.19.1
+protoc_archive := $(tools)/protoc_$(protoc_version).zip
+$(protoc_archive):
+	curl \
+		--fail \
+		--location \
+		--show-error \
+		--silent \
+		--output '$@' \
+		'https://github.com/protocolbuffers/protobuf/releases/download/v$(protoc_version)/protoc-$(protoc_version)-linux-x86_64.zip'
+protoc_dir := $(tools)/protoc_$(protoc_version)
+$(protoc_dir): $(protoc_archive)
+	unzip \
+		'$(protoc_archive)' \
+		-d '$@'
+protoc := $(protoc_dir)/bin/protoc
+$(protoc): $(protoc_dir)


### PR DESCRIPTION
There are no proto files so this is not very useful yet, but it's proof that
downloading protoc and running it via make works.