### PR TITLE
WORKSPACE: set up rules_docker and pull down a Postgres image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,3 +32,28 @@ go_rules_dependencies()
 go_register_toolchains(version = "1.17.5")
 
 gazelle_dependencies()
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "59536e6ae64359b716ba9c46c39183403b01eabfbd57578e84398b4829ca499a",
+    strip_prefix = "rules_docker-0.22.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.22.0/rules_docker-v0.22.0.tar.gz"],
+)
+
+load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
+
+container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+container_pull(
+    name = "postgres_image",
+    digest = "sha256:3691c00fc177519261bc07b06d0aa990bb17e1bfc31dd79662c9dbd432d2d48b",  # tag "14.1" as of 2022-01-01
+    # tag = "14.1",
+    registry = "index.docker.io",
+    repository = "library/postgres",
+)


### PR DESCRIPTION
This is a starting point to running various integration tests using Postgres
running in Docker.