### PR TITLE
runfiles: package to work with Bazel runfiles.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/bazelbuild/bazelisk v1.11.0
 	github.com/bazelbuild/buildtools v0.0.0-20211129135157-cdedcc0318b9
+	github.com/bazelbuild/rules_go v0.29.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v4 v4.14.1

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/bazelbuild/bazelisk v1.11.0 h1:dmESc1UeF8iqJTOPxlPw2DH9ykZEMwdlL/jQ+U
 github.com/bazelbuild/bazelisk v1.11.0/go.mod h1:3zOen/lU/rEGgghOIkqfpO2+PhRXvZyMCA9iqFJ2c9Q=
 github.com/bazelbuild/buildtools v0.0.0-20211129135157-cdedcc0318b9 h1:/PcWeJ3LIWhblotKr02J7SNHIyWDZ7jagXh4TtwaHvY=
 github.com/bazelbuild/buildtools v0.0.0-20211129135157-cdedcc0318b9/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
+github.com/bazelbuild/rules_go v0.29.0 h1:SfxjyO/V68rVnzOHop92fB0gv/Aa75KNLAN0PMqXbIw=
 github.com/bazelbuild/rules_go v0.29.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -68,7 +69,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/runfiles/BUILD.bazel
+++ b/runfiles/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "runfiles",
+    srcs = ["runfiles.go"],
+    importpath = "go.saser.se/runfiles",
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go/tools/bazel:go_default_library"],
+)
+
+go_test(
+    name = "runfiles_test",
+    srcs = ["runfiles_test.go"],
+    data = ["test.txt"],
+    embed = [":runfiles"],
+)

--- a/runfiles/runfiles.go
+++ b/runfiles/runfiles.go
@@ -1,0 +1,64 @@
+// Package runfiles contains functions for working with Bazel runfiles.
+package runfiles
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+// Path returns the full path to the given runfile.
+func Path(name string) (string, error) {
+	return bazel.Runfile(name)
+}
+
+// PathT is like Path but fails the test if the runfile cannot be found.
+func PathT(tb testing.TB, name string) string {
+	tb.Helper()
+	path, err := Path(name)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return path
+}
+
+// Open opens the given runfile.
+func Open(name string) (*os.File, error) {
+	path, err := Path(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(path)
+}
+
+// OpenT is like Open but fails the test if opening the file fails. OpenT
+// arranges for the file to be closed at the end of the test.
+func OpenT(tb testing.TB, name string) *os.File {
+	tb.Helper()
+	f, err := Open(name)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { f.Close() })
+	return f
+}
+
+// Read reads the entire contents of the given runfile.
+func Read(name string) ([]byte, error) {
+	path, err := Path(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+// ReadT is like Read but fails the test if reading the file fails.
+func ReadT(tb testing.TB, name string) []byte {
+	tb.Helper()
+	d, err := Read(name)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return d
+}

--- a/runfiles/runfiles_test.go
+++ b/runfiles/runfiles_test.go
@@ -1,0 +1,88 @@
+package runfiles
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+)
+
+const testfile = "runfiles/test.txt"
+
+func TestPath(t *testing.T) {
+	path, err := Path(testfile)
+	if err != nil {
+		t.Fatalf("Path(%q) err = %v; want nil", testfile, err)
+	}
+	// We can't assert much about the path -- it's too "workstation-dependent".
+	// It should _probably_ be an absolute path, though.
+	if got, want := filepath.IsAbs(path), true; got != want {
+		t.Errorf("filepath.IsAbs(%q) = %v; want %v", path, got, want)
+	}
+	if testing.Verbose() {
+		t.Logf("full path for %q: %q", testfile, path)
+	}
+}
+
+func TestPathT(t *testing.T) {
+	path := PathT(t, testfile)
+	// We can't assert much about the path -- it's too "workstation-dependent".
+	// It should _probably_ be an absolute path, though.
+	if got, want := filepath.IsAbs(path), true; got != want {
+		t.Errorf("filepath.IsAbs(%q) = %v; want %v", path, got, want)
+	}
+	if testing.Verbose() {
+		t.Logf("full path for %q: %q", testfile, path)
+	}
+}
+
+func TestOpen(t *testing.T) {
+	f, err := Open(testfile)
+	if err != nil {
+		t.Fatalf("Open(%q) err = %v; want nil", testfile, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("closing file failed: %v", err)
+		}
+	}()
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("reading file failed: %v", err)
+	}
+	want := []byte("This is an example file to be used in tests.\n")
+	if !bytes.Equal(got, want) {
+		t.Errorf("unexpected file contents\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestOpenT(t *testing.T) {
+	f := OpenT(t, testfile)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("reading file failed: %v", err)
+	}
+	want := []byte("This is an example file to be used in tests.\n")
+	if !bytes.Equal(got, want) {
+		t.Errorf("unexpected file contents\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestRead(t *testing.T) {
+	got, err := Read(testfile)
+	if err != nil {
+		t.Fatalf("Read(%q) err = %v; want nil", testfile, err)
+	}
+	want := []byte("This is an example file to be used in tests.\n")
+	if !bytes.Equal(got, want) {
+		t.Errorf("unexpected file contents\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestReadT(t *testing.T) {
+	got := ReadT(t, testfile)
+	want := []byte("This is an example file to be used in tests.\n")
+	if !bytes.Equal(got, want) {
+		t.Errorf("unexpected file contents\ngot:  %v\nwant: %v", got, want)
+	}
+}

--- a/runfiles/test.txt
+++ b/runfiles/test.txt
@@ -1,0 +1,1 @@
+This is an example file to be used in tests.


### PR DESCRIPTION
I anticipate that at some point I will need all of these functions, so I figured
I'd add it early.