### PR TITLE
docker/imagetar: package to read tar archives containing Docker images.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,3 +57,11 @@ container_pull(
     registry = "index.docker.io",
     repository = "library/postgres",
 )
+
+container_pull(
+    name = "hello_world_image",
+    # tag = "linux",
+    digest = "sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4",  # tag "linux" as of 2022-01-08
+    registry = "index.docker.io",
+    repository = "library/hello-world",
+)

--- a/docker/imagetar/BUILD.bazel
+++ b/docker/imagetar/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+container_image(
+    name = "testimage",
+    base = "@hello_world_image//image",
+)
+
+go_library(
+    name = "imagetar",
+    srcs = ["imagetar.go"],
+    importpath = "go.saser.se/docker/imagetar",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "imagetar_test",
+    srcs = ["imagetar_test.go"],
+    data = [":testimage.tar"],
+    embed = [":imagetar"],
+    deps = [
+        "//runfiles",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+    ],
+)

--- a/docker/imagetar/imagetar.go
+++ b/docker/imagetar/imagetar.go
@@ -1,0 +1,56 @@
+// Package imagetar contains functions for reading tarballs containing Docker
+// images and repositories.
+package imagetar
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var (
+	// ErrRepositoriesNotFound is returned from Repositories when the file
+	// "repositories" is not found at the root of the archive.
+	ErrRepositoriesNotFound = errors.New("imagetar: repositories file not found")
+
+	// ErrRepositoriesInvalid is returned from Repositories when the file
+	// "repositories" is found but does not have the expected JSON structure.
+	ErrRepositoriesInvalid = errors.New("imagetar: repositories file is invalid")
+)
+
+// Repositories reads out the "repositories" file from the root of the archive
+// and parses its contents, which is expected to be JSON, into a map. The map is
+// structed as follows to match the definition of the "repositories" file as
+// described at https://docs.docker.com/engine/api/v1.41/#operation/ImageGet.
+//
+//     repository -> tag -> layer ID
+//
+// If no "repositories" file is found, Repositories returns
+// ErrRepositoriesNotFound. If the file is found but its contents cannot be
+// parsed as JSON, Repositories returns ErrRepositoriesInvalid.
+func Repositories(r io.Reader) (map[string]map[string]string, error) {
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, ErrRepositoriesNotFound
+		}
+		if err != nil {
+			return nil, fmt.Errorf("imagetar: read repositories: %w", err)
+		}
+		if hdr.Name != "repositories" {
+			continue
+		}
+		contents, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("imagetar: read repositories: %w", err)
+		}
+		repositories := make(map[string]map[string]string)
+		if err := json.Unmarshal(contents, &repositories); err != nil {
+			return nil, ErrRepositoriesInvalid
+		}
+		return repositories, nil
+	}
+}

--- a/docker/imagetar/imagetar_test.go
+++ b/docker/imagetar/imagetar_test.go
@@ -1,0 +1,96 @@
+package imagetar
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.saser.se/runfiles"
+)
+
+var testimage = runfiles.MustRead("docker/imagetar/testimage.tar")
+
+// replaceFile reads the given tar archive, replaces the named file with the
+// given contents, and returns the resulting archive as a byte slice. As a
+// special case, if contents is nil the named file is not written to the new
+// archive, effectively deleting it.
+func replaceFile(t *testing.T, archive []byte, name string, contents []byte) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	tw := tar.NewWriter(&out)
+	tr := tar.NewReader(bytes.NewReader(archive))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body []byte
+		if hdr.Name == name {
+			if contents == nil {
+				continue
+			}
+			hdr.Size = int64(len(contents))
+			body = contents
+		} else {
+			var err error
+			body, err = io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return out.Bytes()
+}
+
+func TestRepositories(t *testing.T) {
+	want := map[string]map[string]string{
+		"bazel/docker/imagetar": {
+			"testimage": "a5f34025714d147c8ad37b8e237b52af7b58a5f44be46a5e550f0873705d1f24",
+		},
+	}
+	got, err := Repositories(bytes.NewReader(testimage))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Repositories: unexpected return value (-want +got)\n%s", diff)
+	}
+}
+
+func TestRepositories_Error(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		r    io.Reader
+		want error
+	}{
+		{
+			name: "NotFound",
+			r:    bytes.NewReader(replaceFile(t, testimage, "repositories", nil)),
+			want: ErrRepositoriesNotFound,
+		},
+		{
+			name: "Invalid",
+			r:    bytes.NewReader(replaceFile(t, testimage, "repositories", []byte("this is not JSON"))),
+			want: ErrRepositoriesInvalid,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := Repositories(tt.r)
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("unexpected error from Repositories (-want +got)\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Mostly I will use this to extract the right image name when loading images into
the Docker daemon in integration tests. This is instead of

1. parsing them out of the log messages from the load API call; or
2. assuming the name begins with "bazel/" and then follows the specific format.

I could _probably_ have used the latter, but this was a fun exercise in learning
how to deal with tar archives in Go.