### PR TITLE
docker/imagetar: add Images function to read out image names.

### DIFF
--- a/docker/imagetar/BUILD.bazel
+++ b/docker/imagetar/BUILD.bazel
@@ -1,9 +1,23 @@
+load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 container_image(
-    name = "testimage",
+    name = "testimage_hello_world",
     base = "@hello_world_image//image",
+)
+
+container_image(
+    name = "testimage_postgres",
+    base = "@postgres_image//image",
+)
+
+container_bundle(
+    name = "testbundle",
+    images = {
+        "bazel/docker/imagetar:testimage_hello_world": ":testimage_hello_world",
+        "bazel/docker/imagetar:testimage_postgres": ":testimage_postgres",
+    },
 )
 
 go_library(
@@ -16,7 +30,10 @@ go_library(
 go_test(
     name = "imagetar_test",
     srcs = ["imagetar_test.go"],
-    data = [":testimage.tar"],
+    data = [
+        "testbundle.tar",
+        "testimage_hello_world.tar",
+    ],
     embed = [":imagetar"],
     deps = [
         "//runfiles",

--- a/docker/imagetar/imagetar.go
+++ b/docker/imagetar/imagetar.go
@@ -54,3 +54,20 @@ func Repositories(r io.Reader) (map[string]map[string]string, error) {
 		return repositories, nil
 	}
 }
+
+// Images parses the "repositories" file at the root of the archive and returns
+// a list of image names contained in that archive. The strings will have the
+// format "path/to/repo:tag".
+func Images(r io.Reader) ([]string, error) {
+	repos, err := Repositories(r)
+	if err != nil {
+		return nil, err
+	}
+	var images []string
+	for repo, tags := range repos {
+		for tag := range tags {
+			images = append(images, repo+":"+tag)
+		}
+	}
+	return images, nil
+}


### PR DESCRIPTION
This is basically a wrapper around Repositories to convert the map structure
into a list of image names. These image names can then be referred to when
creating containers, etc.