### PR TITLE
tasks/service: update integration tests to use package postgrestest.

### DIFF
--- a/tasks/postgres/BUILD.bazel
+++ b/tasks/postgres/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["schema.sql"])

--- a/tasks/service/BUILD.bazel
+++ b/tasks/service/BUILD.bazel
@@ -19,13 +19,13 @@ go_library(
 go_test(
     name = "service_test",
     srcs = ["service_test.go"],
+    data = ["//tasks/postgres:schema.sql"],
     deps = [
         ":service",
+        "//postgres/postgrestest",
         "//tasks/tasks_go_proto",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_uuid//:uuid",
-        "@com_github_jackc_pgx_v4//:pgx",
-        "@com_github_jackc_pgx_v4//pgxpool",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",


### PR DESCRIPTION
There are also some other enhancements:

    1. Since `postgrestest` always creates new containers we can run tests in
       parallel.
    2. There are new tests for error conditions for `CreateTask`.
    3. Some error messages have been tweaked.