### PR TITLE
postgres: package for connecting to Postgres databases.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bazelbuild/rules_go v0.29.0
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/golang/glog v1.0.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v4 v4.14.1

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/postgres/BUILD.bazel
+++ b/postgres/BUILD.bazel
@@ -1,7 +1,19 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 container_image(
     name = "image",
     base = "@postgres_image//image",
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "postgres",
+    srcs = ["postgres.go"],
+    importpath = "go.saser.se/postgres",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//postgres/log/glogadapter",
+        "@com_github_jackc_pgx_v4//pgxpool",
+    ],
 )

--- a/postgres/log/glogadapter/BUILD.bazel
+++ b/postgres/log/glogadapter/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "glogadapter",
+    srcs = ["glogadapter.go"],
+    importpath = "go.saser.se/postgres/log/glogadapter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_glog//:glog",
+        "@com_github_jackc_pgx_v4//:pgx",
+    ],
+)

--- a/postgres/log/glogadapter/glogadapter.go
+++ b/postgres/log/glogadapter/glogadapter.go
@@ -1,0 +1,51 @@
+// Package glogadapter contains an implementation of the pgx.Logger interface
+// for the glog package.
+package glogadapter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/jackc/pgx/v4"
+)
+
+// Logger implements pgx.Logger.
+type Logger struct{}
+
+// NewLogger returns a new Logger ready for use.
+func NewLogger() *Logger {
+	return &Logger{}
+}
+
+// Log implements pgx.Logger.Log. LogLevelTrace and LogLevelDebug are written to
+// the INFO level with a "(level)" prefix. LogLevelNone, as well as the zero
+// value for LogLevel, are written to the ERROR level with a "(level)" prefix.
+func (l *Logger) Log(ctx context.Context, level pgx.LogLevel, msg string, data map[string]interface{}) {
+	var sb strings.Builder
+	sb.WriteString(msg)
+	sb.WriteString(" [")
+	writeSeparator := false
+	for k, v := range data {
+		if writeSeparator {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(k + "=" + fmt.Sprint(v))
+		writeSeparator = true
+	}
+	sb.WriteString("]")
+	s := sb.String()
+	switch level {
+	case pgx.LogLevelTrace, pgx.LogLevelDebug:
+		glog.InfoDepth(2, "("+level.String()+") "+s)
+	case pgx.LogLevelInfo:
+		glog.InfoDepth(2, s)
+	case pgx.LogLevelWarn:
+		glog.WarningDepth(2, s)
+	case pgx.LogLevelError:
+		glog.ErrorDepth(2, s)
+	default:
+		glog.ErrorDepth(2, "("+level.String()+") "+s)
+	}
+}

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -1,0 +1,53 @@
+// Package postgres provides interactions with Postgres databases. It does so by
+// wrapping the pgxpool package.
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"go.saser.se/postgres/log/glogadapter"
+)
+
+const retryInterval = 1 * time.Second
+
+// Pool contains a connection pool to a Postgres database.
+type Pool struct {
+	*pgxpool.Pool
+}
+
+// Open connects using the given connection string, retrying until either the
+// connection succeeds or the context is cancelled.
+func Open(ctx context.Context, connString string) (*Pool, error) {
+	cfg, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: open: %w", err)
+	}
+	cfg.ConnConfig.Logger = glogadapter.NewLogger()
+	pool, err := openConfigWithRetry(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: open: %w", err)
+	}
+	return pool, err
+}
+
+// openConfigWithRetry implements linear backoff to connect with the given
+// config until either the connection succeeds or the context is cancelled.
+func openConfigWithRetry(ctx context.Context, cfg *pgxpool.Config) (*Pool, error) {
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			pool, err := pgxpool.ConnectConfig(ctx, cfg)
+			if err != nil {
+				continue
+			}
+			return &Pool{Pool: pool}, nil
+		}
+	}
+}

--- a/postgres/postgrestest/BUILD.bazel
+++ b/postgres/postgrestest/BUILD.bazel
@@ -8,8 +8,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//docker/dockertest",
+        "//postgres",
         "//runfiles",
-        "@com_github_jackc_pgx_v4//pgxpool",
     ],
 )
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -775,8 +775,8 @@ def go_repositories():
     go_repository(
         name = "com_github_golang_glog",
         importpath = "github.com/golang/glog",
-        sum = "h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=",
-        version = "v0.0.0-20160126235308-23def4e6c14b",
+        sum = "h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=",
+        version = "v1.0.0",
     )
     go_repository(
         name = "com_github_golang_groupcache",

--- a/tasks/service/BUILD.bazel
+++ b/tasks/service/BUILD.bazel
@@ -6,10 +6,10 @@ go_library(
     importpath = "go.saser.se/tasks/service",
     visibility = ["//visibility:public"],
     deps = [
+        "//postgres",
         "//tasks/tasks_go_proto",
         "@com_github_google_uuid//:uuid",
         "@com_github_jackc_pgx_v4//:pgx",
-        "@com_github_jackc_pgx_v4//pgxpool",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/emptypb",

--- a/tasks/service/service.go
+++ b/tasks/service/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
+	"go.saser.se/postgres"
 	pb "go.saser.se/tasks/tasks_go_proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,10 +20,10 @@ import (
 type Service struct {
 	pb.UnimplementedTasksServer
 
-	pool *pgxpool.Pool
+	pool *postgres.Pool
 }
 
-func New(pool *pgxpool.Pool) *Service {
+func New(pool *postgres.Pool) *Service {
 	return &Service{
 		pool: pool,
 	}


### PR DESCRIPTION
The purpose of this package is to provide some sane defaults for retrying
connections, adding logging, and possibly other features in the future. By
embedding the `*pgxpool.Pool` type into the `Pool` type, and forcing callers to
use `Pool`, we get some help from the compiler to make sure these sane defaults
are actually used, while keeping compatibility with the `pgx` interface.

This change also includes a simple log adapter for `glog`, which is always
installed in any call to `Open`.