### PR TITLE
tasks: define, test, and implement ListTasks.

### DIFF
--- a/tasks/postgres/BUILD.bazel
+++ b/tasks/postgres/BUILD.bazel
@@ -1,1 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
 exports_files(["schema.sql"])
+
+go_test(
+    name = "postgres_test",
+    srcs = ["schema_test.go"],
+    data = ["schema.sql"],
+    deps = ["//postgres/postgrestest"],
+)

--- a/tasks/postgres/schema.sql
+++ b/tasks/postgres/schema.sql
@@ -1,14 +1,26 @@
 BEGIN;
 
+-- The main table of tasks.
 CREATE TABLE tasks (
-    uuid UUID NOT NULL,
+    id BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
     title TEXT NOT NULL,
     description TEXT NOT NULL,
     completed BOOLEAN NOT NULL,
     create_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    delete_time TIMESTAMP WITH TIME ZONE, -- If non-null, then task is considered deleted.
 
-    PRIMARY KEY (uuid),
-    CONSTRAINT title_not_empty CHECK (title <> '')
+    PRIMARY KEY (id),
+    CONSTRAINT title_not_empty CHECK (title <> ''),
+    CONSTRAINT create_time_before_delete_time CHECK (delete_time IS NULL OR create_time < delete_time)
+);
+
+-- A table of page tokens. The rows in this table define the set of acceptable
+-- values for ListTasksRequest.next_page_token.
+CREATE TABLE page_tokens (
+    token UUID NOT NULL,
+    minimum_id BIGINT NOT NULL REFERENCES tasks (id),
+
+    PRIMARY KEY (token)
 );
 
 COMMIT;

--- a/tasks/postgres/schema_test.go
+++ b/tasks/postgres/schema_test.go
@@ -1,0 +1,14 @@
+package schema_test
+
+import (
+	"context"
+	"testing"
+
+	"go.saser.se/postgres/postgrestest"
+)
+
+func TestSchema(t *testing.T) {
+	// Open creates a Postgres database and executes the SQL statements in the
+	// schema. If the execution fails, Open fails the test.
+	postgrestest.Open(context.Background(), t, "tasks/postgres/schema.sql")
+}

--- a/tasks/service/BUILD.bazel
+++ b/tasks/service/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//postgres",
         "//tasks/tasks_go_proto",
+        "@com_github_golang_glog//:glog",
         "@com_github_google_uuid//:uuid",
         "@com_github_jackc_pgx_v4//:pgx",
         "@org_golang_google_grpc//codes",
@@ -21,17 +22,18 @@ go_test(
     name = "service_test",
     srcs = ["service_test.go"],
     data = ["//tasks/postgres:schema.sql"],
+    embed = [":service"],
     deps = [
-        ":service",
         "//postgres/postgrestest",
         "//tasks/tasks_go_proto",
         "@com_github_google_go_cmp//cmp",
-        "@com_github_google_uuid//:uuid",
+        "@com_github_google_go_cmp//cmp/cmpopts",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//status",
         "@org_golang_google_grpc//test/bufconn",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/tasks/service/service.go
+++ b/tasks/service/service.go
@@ -3,10 +3,13 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
 	"go.saser.se/postgres"
@@ -16,6 +19,16 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// maxPageSize is the maximum number of tasks the server will return on a call
+// to ListTasks. Any request for more than maxPageSize tasks will only return
+// (at most) maxPageSize tasks.
+const maxPageSize = 1000
+
+// internalError should be returned whenever something goes wrong with serving a
+// request, and where the error cannot be attributed to the user making an
+// invalid request, something cannot be found, etc.
+var internalError = status.Error(codes.Internal, "Something went wrong.")
 
 type Service struct {
 	pb.UnimplementedTasksServer
@@ -37,7 +50,7 @@ func (s *Service) GetTask(ctx context.Context, req *pb.GetTaskRequest) (*pb.Task
 	if !strings.HasPrefix(name, "tasks/") {
 		return nil, status.Errorf(codes.InvalidArgument, `The name of the task must have format "tasks/{task}", but it was %q.`, name)
 	}
-	id, err := uuid.Parse(strings.TrimPrefix(name, "tasks/"))
+	id, err := strconv.ParseInt(strings.TrimPrefix(name, "tasks/"), 10, 64)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "A task with name %q does not exist.", name)
 	}
@@ -55,9 +68,10 @@ SELECT
 FROM
     tasks
 WHERE
-	uuid = $1
+	id = $1
+	AND delete_time IS NULL
 `)
-		return tx.QueryRow(ctx, sql, id).Scan(
+		return tx.QueryRow(ctx, sql, id /* $1 */).Scan(
 			&task.Title,
 			&task.Description,
 			&task.Completed,
@@ -67,10 +81,148 @@ WHERE
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "A task with name %q does not exist.", name)
 		}
-		return nil, status.Error(codes.Internal, "Something went wrong.")
+		return nil, internalError
 	}
 	task.CreateTime = timestamppb.New(createTime)
 	return task, nil
+}
+
+func (s *Service) ListTasks(ctx context.Context, req *pb.ListTasksRequest) (res *pb.ListTasksResponse, err error) {
+	pageSize := req.GetPageSize()
+	if pageSize < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "The page size must not be negative; was %d.", pageSize)
+	}
+	if pageSize == 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		glog.Error(err)
+		return nil, internalError
+	}
+	defer func() {
+		var txErr error
+		if err == nil {
+			txErr = tx.Commit(ctx)
+		} else {
+			txErr = tx.Rollback(ctx)
+		}
+		if txErr != nil {
+			glog.Error(err)
+		}
+	}()
+
+	minID := int64(0)
+	if token := req.GetPageToken(); token != "" {
+		sql := strings.TrimSpace(`
+DELETE
+FROM
+    page_tokens
+WHERE
+    token = $1
+RETURNING
+    minimum_id
+		`)
+		if err := tx.QueryRow(ctx, sql, token /* $1 */).Scan(&minID); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "The page token %q is invalid.", token)
+		}
+	}
+
+	// List the tasks. We increase the limit by 1 so that we know whether there
+	// is at least one more task after the ones included in the current page,
+	// meaning that we should return a non-empty next_page_token.
+	var tasks []*pb.Task
+	tasksSQL := strings.TrimSpace(`
+SELECT
+	id,
+	title,
+	description,
+	completed,
+	create_time
+FROM
+	tasks
+WHERE
+	id >= $1
+	AND delete_time IS NULL
+ORDER BY id ASC
+LIMIT $2
+	`)
+	// These variables correspond to the selected columns.
+	var (
+		id          int64
+		title       string
+		description string
+		completed   bool
+		createTime  time.Time
+	)
+	// nextMinID is used to determine the minimum ID for the next page of
+	// results, if any.
+	var nextMinID int64
+	_, err = tx.QueryFunc(ctx, tasksSQL,
+		[]interface{}{
+			minID,        // $1
+			pageSize + 1, // $2 -- see comment above about why we increase the limit by one.
+		},
+		[]interface{}{
+			&id,
+			&title,
+			&description,
+			&completed,
+			&createTime,
+		},
+		func(_ pgx.QueryFuncRow) error {
+			tasks = append(tasks, &pb.Task{
+				Name:        "tasks/" + fmt.Sprint(id),
+				Title:       title,
+				Description: description,
+				Completed:   completed,
+				CreateTime:  timestamppb.New(createTime),
+			})
+			// The last row returned will (possibly) be the minimum ID in the
+			// next page. Instead of checking len(tasks) to figure out if we are
+			// on the next page, we can just set this here.
+			nextMinID = id
+			return nil
+		},
+	)
+	if err != nil {
+		glog.Error(err)
+		return nil, internalError
+	}
+
+	// If we listed no tasks (maybe because there are none) there will be no
+	// more pages, so we can do an early return here.
+	if len(tasks) == 0 {
+		return &pb.ListTasksResponse{}, nil
+	}
+
+	// We saw at least one task. If the number of tasks is less than or equal to
+	// pageSize, there will be no more pages.
+	if int32(len(tasks)) <= pageSize {
+		return &pb.ListTasksResponse{Tasks: tasks}, nil
+	}
+
+	// There will be at least one more page. Create the page token, use the ID
+	// from the extra task as the mininum ID, and return the page token.
+	token := uuid.New()
+	tokenSQL := strings.TrimSpace(`
+INSERT INTO page_tokens (token, minimum_id)
+VALUES                  ($1,    $2        )
+	`)
+	_, err = tx.Exec(ctx, tokenSQL,
+		token,     // $1
+		nextMinID, // $2
+	)
+	if err != nil {
+		glog.Error(err)
+		return nil, internalError
+	}
+
+	return &pb.ListTasksResponse{
+		Tasks:         tasks[:pageSize],
+		NextPageToken: token.String(),
+	}, nil
 }
 
 func (s *Service) CreateTask(ctx context.Context, req *pb.CreateTaskRequest) (*pb.Task, error) {
@@ -81,30 +233,34 @@ func (s *Service) CreateTask(ctx context.Context, req *pb.CreateTaskRequest) (*p
 	if task.GetCompleted() {
 		return nil, status.Error(codes.InvalidArgument, "The task must not already be completed.")
 	}
-	id := uuid.New()
-	task.Name = "tasks/" + id.String()
 	err := s.pool.BeginFunc(ctx, func(tx pgx.Tx) error {
 		sql := strings.TrimSpace(`
-INSERT INTO tasks (uuid, title, description, completed, create_time)
-VALUES            ($1,   $2,    $3,          $4,        NOW()      )
-RETURNING create_time
+INSERT INTO tasks (title, description, completed, create_time)
+VALUES            ($1,    $2,          $3,        NOW()      )
+RETURNING id, create_time
 `)
-		var createTime time.Time
+		var (
+			id         int64
+			createTime time.Time
+		)
 		err := tx.QueryRow(ctx, sql,
-			id,                    // $1
-			task.GetTitle(),       // $2
-			task.GetDescription(), // $3
-			task.GetCompleted(),   // $4
-		).Scan(&createTime)
+			task.GetTitle(),       // $1
+			task.GetDescription(), // $2
+			task.GetCompleted(),   // $3
+		).Scan(
+			&id,
+			&createTime,
+		)
 		if err != nil {
 			log.Print(err)
 		} else {
+			task.Name = "tasks/" + fmt.Sprint(id)
 			task.CreateTime = timestamppb.New(createTime)
 		}
 		return err
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, "Something went wrong.")
+		return nil, internalError
 	}
 	return task, nil
 }
@@ -117,17 +273,21 @@ func (s *Service) DeleteTask(ctx context.Context, req *pb.DeleteTaskRequest) (*e
 	if !strings.HasPrefix(name, "tasks/") {
 		return nil, status.Errorf(codes.InvalidArgument, `The name of the task must have format "tasks/{task}", but it was %q.`, name)
 	}
-	id, err := uuid.Parse(strings.TrimPrefix(name, "tasks/"))
+	id, err := strconv.ParseInt(strings.TrimPrefix(name, "tasks/"), 10, 64)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, `The name of the task must have format "tasks/{task}", but it was %q.`, name)
+		return nil, status.Errorf(codes.NotFound, "A task with name %q does not exist.", name)
 	}
 	errNotFound := errors.New("not found")
 	txFunc := func(tx pgx.Tx) error {
 		sql := strings.TrimSpace(`
-DELETE FROM tasks
-WHERE uuid = $1
+UPDATE tasks
+SET
+    delete_time = NOW()
+WHERE
+    id = $1
+	AND delete_time IS NULL
 `)
-		tag, err := tx.Exec(ctx, sql, id)
+		tag, err := tx.Exec(ctx, sql, id /* $1 */)
 		if err != nil {
 			log.Print(err)
 			return err
@@ -141,7 +301,7 @@ WHERE uuid = $1
 		if errors.Is(err, errNotFound) {
 			return nil, status.Errorf(codes.NotFound, "A task with name %q does not exist.", name)
 		}
-		return nil, status.Error(codes.Internal, "Something went wrong.")
+		return nil, internalError
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/tasks/service/service_test.go
+++ b/tasks/service/service_test.go
@@ -1,22 +1,27 @@
-package service_test
+package service
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.saser.se/postgres/postgrestest"
-	"go.saser.se/tasks/service"
 	pb "go.saser.se/tasks/tasks_go_proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
+
+func taskLessFunc(t1, t2 *pb.Task) bool {
+	return t1.GetName() < t2.GetName()
+}
 
 type testClient struct {
 	pb.TasksClient
@@ -31,6 +36,31 @@ func (c *testClient) GetTaskT(ctx context.Context, t *testing.T, req *pb.GetTask
 	return task
 }
 
+func (c *testClient) ListTasksT(ctx context.Context, t *testing.T, req *pb.ListTasksRequest) *pb.ListTasksResponse {
+	t.Helper()
+	res, err := c.ListTasks(ctx, req)
+	if err != nil {
+		t.Fatalf("ListTasks(%v) err = %v; want nil", req, err)
+	}
+	return res
+}
+
+func (c *testClient) ListAllTasksT(ctx context.Context, t *testing.T, req *pb.ListTasksRequest) []*pb.Task {
+	t.Helper()
+	var tasks []*pb.Task
+	req = proto.Clone(req).(*pb.ListTasksRequest)
+	for {
+		res := c.ListTasksT(ctx, t, req)
+		tasks = append(tasks, res.GetTasks()...)
+		token := res.GetNextPageToken()
+		if token == "" {
+			break
+		}
+		req.PageToken = token
+	}
+	return tasks
+}
+
 func (c *testClient) CreateTaskT(ctx context.Context, t *testing.T, req *pb.CreateTaskRequest) *pb.Task {
 	t.Helper()
 	task, err := c.CreateTask(ctx, req)
@@ -38,6 +68,17 @@ func (c *testClient) CreateTaskT(ctx context.Context, t *testing.T, req *pb.Crea
 		t.Fatalf("CreateTask(%v) err = %v; want nil", req, err)
 	}
 	return task
+}
+
+func (c *testClient) CreateTasksT(ctx context.Context, t *testing.T, tasks []*pb.Task) []*pb.Task {
+	t.Helper()
+	var created []*pb.Task
+	for _, task := range tasks {
+		created = append(created, c.CreateTaskT(ctx, t, &pb.CreateTaskRequest{
+			Task: task,
+		}))
+	}
+	return created
 }
 
 func (c *testClient) DeleteTaskT(ctx context.Context, t *testing.T, req *pb.DeleteTaskRequest) {
@@ -60,7 +101,7 @@ func setup(ctx context.Context, t *testing.T) *testClient {
 	})
 
 	srv := grpc.NewServer()
-	svc := service.New(postgrestest.Open(ctx, t, "tasks/postgres/schema.sql"))
+	svc := New(postgrestest.Open(ctx, t, "tasks/postgres/schema.sql"))
 	pb.RegisterTasksServer(srv, svc)
 	errc := make(chan error, 1)
 	go func() {
@@ -175,20 +216,21 @@ func TestService_GetTask_Error(t *testing.T) {
 		},
 		{
 			name: "InvalidName",
-			req:  &pb.GetTaskRequest{Name: "invalid/" + uuid.NewString()},
+			req:  &pb.GetTaskRequest{Name: "invalid/123"},
 			want: codes.InvalidArgument,
 		},
 		{
-			name: "NotFound_UUID",
-			req:  &pb.GetTaskRequest{Name: "tasks/" + uuid.NewString()},
+			name: "NotFound",
+			req:  &pb.GetTaskRequest{Name: "tasks/999"},
 			want: codes.NotFound,
 		},
 		{
-			name: "NotFound_NotUUID",
+			name: "NotFound_DifferentResourceIDFormat",
 			req: &pb.GetTaskRequest{
-				// This is a valid name -- there is no guarantee that the name
-				// will be a UUID.
-				Name: "tasks/1",
+				// This is a valid name -- there is no guarantee what format the
+				// resource ID (the segment after the slash) will have. But it
+				// probably won't be arbitrary strings.
+				Name: "tasks/invalidlol",
 			},
 			want: codes.NotFound,
 		},
@@ -199,6 +241,283 @@ func TestService_GetTask_Error(t *testing.T) {
 				t.Errorf("GetTask(%v) code = %v; want %v", tt.req, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestService_ListTasks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := setup(ctx, t)
+
+	want := c.CreateTasksT(ctx, t, []*pb.Task{
+		{Title: "Buy milk"},
+		{Title: "Do the laundry"},
+		{Title: "Get swole"},
+	})
+
+	req := &pb.ListTasksRequest{
+		PageSize: int32(len(want)),
+	}
+	res, err := c.ListTasks(ctx, req)
+	if err != nil {
+		t.Fatalf("ListTasks(%v) err = %v; want nil", req, err)
+	}
+	if diff := cmp.Diff(want, res.GetTasks(), protocmp.Transform(), cmpopts.SortSlices(taskLessFunc)); diff != "" {
+		t.Errorf("ListTasks(%v): unexpected result (-want +got)\n%s", req, diff)
+	}
+	if got, want := res.GetNextPageToken(), ""; got != want {
+		t.Errorf("ListTasks(%v) next_page_token = %q; want %q", req, got, want)
+	}
+}
+
+func TestService_ListTasks_MaxPageSize(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := setup(ctx, t)
+
+	tasks := make([]*pb.Task, maxPageSize*2-maxPageSize/2)
+	for i := range tasks {
+		tasks[i] = &pb.Task{
+			Title: fmt.Sprint(i),
+		}
+	}
+	tasks = c.CreateTasksT(ctx, t, tasks)
+
+	req := &pb.ListTasksRequest{
+		PageSize: int32(len(tasks)), // more than maxPageSize
+	}
+
+	res := c.ListTasksT(ctx, t, req)
+	wantFirstPage := tasks[:maxPageSize]
+	if diff := cmp.Diff(wantFirstPage, res.GetTasks(), protocmp.Transform(), cmpopts.SortSlices(taskLessFunc)); diff != "" {
+		t.Errorf("[first page] ListTasks(%v): unexpected result (-want +got)\n%s", req, diff)
+	}
+
+	req.PageToken = res.GetNextPageToken()
+	res = c.ListTasksT(ctx, t, req)
+	wantSecondPage := tasks[maxPageSize:]
+	if diff := cmp.Diff(wantSecondPage, res.GetTasks(), protocmp.Transform(), cmpopts.SortSlices(taskLessFunc)); diff != "" {
+		t.Errorf("[second page] ListTasks(%v): unexpected result (-want +got)\n%s", req, diff)
+	}
+}
+
+func TestService_ListTasks_DifferentPageSizes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := setup(ctx, t)
+
+	// 7 tasks. Number chosen arbitrarily.
+	tasks := c.CreateTasksT(ctx, t, []*pb.Task{
+		{Title: "Buy milk"},
+		{Title: "Make pancakes"},
+		{Title: "Read a book"},
+		{Title: "Get swole"},
+		{Title: "Drink water"},
+		{Title: "Get even swoler"},
+		{Title: "Order a new chair"},
+	})
+	for _, sizes := range [][]int32{
+		{1, 1, 1, 1, 1, 1, 1},
+		{7},
+		{8},
+		{1, 6},
+		{6, 1},
+		{6, 7},
+		{1, 7},
+		{2, 2, 2, 2},
+	} {
+		sizes := sizes
+		t.Run(fmt.Sprint(sizes), func(t *testing.T) {
+			t.Parallel()
+			// Sanity check: make sure the sizes add up to at least the number
+			// of tasks, and that we won't try to get more pages after the last one.
+			{
+				sum := int32(0)
+				for i, s := range sizes {
+					if s <= 0 {
+						t.Errorf("sizes[%d] = %v; want a positive number", i, s)
+					}
+					sum += s
+				}
+				n := int32(len(tasks))
+				if sum < n {
+					t.Errorf("sum(%v) = %v; want at least %v", sizes, sum, n)
+				}
+				if subsum := sum - sizes[len(sizes)-1]; subsum > n {
+					t.Errorf("[everything except last element] sum(%v) = %v; want less than %v", sizes[:len(sizes)-1], subsum, n)
+				}
+				if t.Failed() {
+					t.FailNow()
+				}
+			}
+			// Now we can start listing tasks.
+			req := &pb.ListTasksRequest{}
+			var got []*pb.Task
+			for i, s := range sizes {
+				req.PageSize = s
+				res := c.ListTasksT(ctx, t, req)
+				got = append(got, res.GetTasks()...)
+				token := res.GetNextPageToken()
+				if i < len(sizes)-1 && token == "" {
+					// This error does not apply for the last page.
+					t.Fatalf("[after page %d]: ListTasks(%v) next_page_token = %q; want non-empty", i, req, token)
+				}
+				req.PageToken = token
+			}
+			// After all the page sizes the page token should be empty.
+			if got, want := req.GetPageToken(), ""; got != want {
+				t.Fatalf("[after all pages] page_token = %q; want %q", got, want)
+			}
+			if diff := cmp.Diff(tasks, got, protocmp.Transform(), cmpopts.SortSlices(taskLessFunc)); diff != "" {
+				t.Errorf("unexpected result (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestService_ListTasks_WithDeletions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	seed := []*pb.Task{
+		{Title: "First task"},
+		{Title: "Second task"},
+		{Title: "Third task"},
+	}
+
+	for _, tt := range []struct {
+		name                  string
+		firstPageSize         int32
+		wantFirstPageIndices  []int // indices into created tasks
+		deleteIndex           int
+		wantSecondPageIndices []int // indices into created tasks
+	}{
+		{
+			name:                  "DeleteInFirstPage_TwoTasksInFirstPage",
+			firstPageSize:         2,
+			wantFirstPageIndices:  []int{0, 1},
+			deleteIndex:           1,
+			wantSecondPageIndices: []int{2},
+		},
+		{
+			name:                  "DeleteInFirstPage_OneTaskInFirstPage",
+			firstPageSize:         1,
+			wantFirstPageIndices:  []int{0},
+			deleteIndex:           0,
+			wantSecondPageIndices: []int{1, 2},
+		},
+		{
+			name:                  "DeleteInSecondPage_DeleteFirst",
+			firstPageSize:         1,
+			wantFirstPageIndices:  []int{0},
+			deleteIndex:           1,
+			wantSecondPageIndices: []int{2},
+		},
+		{
+			name:                  "DeleteInSecondPage_DeleteSecond",
+			firstPageSize:         1,
+			wantFirstPageIndices:  []int{0},
+			deleteIndex:           2,
+			wantSecondPageIndices: []int{1},
+		},
+		{
+			name:                  "DeleteInSecondPage_TwoTasksInFirstPage",
+			firstPageSize:         2,
+			wantFirstPageIndices:  []int{0, 1},
+			deleteIndex:           2,
+			wantSecondPageIndices: []int{},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := setup(ctx, t)
+			tasks := c.CreateTasksT(ctx, t, seed)
+
+			// Get the first page and assert that it matches what we want.
+			req := &pb.ListTasksRequest{
+				PageSize: tt.firstPageSize,
+			}
+			res := c.ListTasksT(ctx, t, req)
+			wantFirstPage := make([]*pb.Task, 0, len(tt.wantFirstPageIndices))
+			for _, idx := range tt.wantFirstPageIndices {
+				wantFirstPage = append(wantFirstPage, tasks[idx])
+			}
+			if diff := cmp.Diff(wantFirstPage, res.GetTasks(), protocmp.Transform(), protocmp.SortRepeated(taskLessFunc)); diff != "" {
+				t.Fatalf("first page: unexpected tasks (-want +got)\n%s", diff)
+			}
+			token := res.GetNextPageToken()
+			if token == "" {
+				t.Fatal("no next page token from first page")
+			}
+			req.PageToken = token
+
+			// Delete one of the tasks.
+			c.DeleteTaskT(ctx, t, &pb.DeleteTaskRequest{
+				Name: tasks[tt.deleteIndex].GetName(),
+			})
+
+			// Get the second page and assert that it matches what we want. Also
+			// assert that there are no more tasks.
+			req.PageSize = int32(len(tasks)) // Make sure we get the remaining tasks.
+			res = c.ListTasksT(ctx, t, req)
+			wantSecondPage := make([]*pb.Task, 0, len(tt.wantSecondPageIndices))
+			for _, idx := range tt.wantSecondPageIndices {
+				wantSecondPage = append(wantSecondPage, tasks[idx])
+			}
+			if diff := cmp.Diff(wantSecondPage, res.GetTasks(), cmpopts.EquateEmpty(), protocmp.Transform(), protocmp.SortRepeated(taskLessFunc)); diff != "" {
+				t.Fatalf("second page: unexpected tasks (-want +got)\n%s", diff)
+			}
+			if got, want := res.GetNextPageToken(), ""; got != want {
+				t.Errorf("second page: next_page_token = %q; want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestService_ListTasks_SamePageTokenTwice(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := setup(ctx, t)
+
+	tasks := c.CreateTasksT(ctx, t, []*pb.Task{
+		{Title: "Buy milk"},
+		{Title: "Do the laundry"},
+		{Title: "Get swole"},
+	})
+
+	// Get the first page.
+	res := c.ListTasksT(ctx, t, &pb.ListTasksRequest{
+		PageSize: int32(len(tasks) - 1), // Make sure we need at least one other page.
+	})
+	wantFirstPage := tasks[:len(tasks)-1]
+	if diff := cmp.Diff(wantFirstPage, res.GetTasks(), protocmp.Transform(), protocmp.SortRepeated(taskLessFunc)); diff != "" {
+		t.Errorf("unexpected first page (-want +got)\n%s", diff)
+	}
+	token := res.GetNextPageToken()
+	if token == "" {
+		t.Fatalf("first page returned empty next_page_token")
+	}
+
+	// Get the second page.
+	req := &pb.ListTasksRequest{
+		PageSize:  int32(len(tasks)), // Make sure we try to get everything.
+		PageToken: token,
+	}
+	res = c.ListTasksT(ctx, t, req)
+	wantSecondPage := tasks[len(tasks)-1:]
+	if diff := cmp.Diff(wantSecondPage, res.GetTasks(), protocmp.Transform(), protocmp.SortRepeated(taskLessFunc)); diff != "" {
+		t.Errorf("unexpected second page (-want +got)\n%s", diff)
+	}
+	if got, want := res.GetNextPageToken(), ""; got != want {
+		t.Errorf("second page: next_page_token = %q; want %q", got, want)
+	}
+
+	// Now try getting the second page again. This shouldn't work -- the last
+	// page token should have been "consumed".
+	_, err := c.ListTasks(ctx, req)
+	if got, want := status.Code(err), codes.InvalidArgument; got != want {
+		t.Errorf("second page again: return code = %v; want %v", got, want)
 	}
 }
 
@@ -313,12 +632,12 @@ func TestService_DeleteTask_Error(t *testing.T) {
 		},
 		{
 			name: "NotFound",
-			req:  &pb.DeleteTaskRequest{Name: "tasks/" + uuid.NewString()},
+			req:  &pb.DeleteTaskRequest{Name: "tasks/notfound"},
 			want: codes.NotFound,
 		},
 		{
 			name: "InvalidName",
-			req:  &pb.DeleteTaskRequest{Name: "invalidlololol/" + uuid.NewString()},
+			req:  &pb.DeleteTaskRequest{Name: "invalidlololol/1"},
 			want: codes.InvalidArgument,
 		},
 	} {

--- a/tasks/tasks.proto
+++ b/tasks/tasks.proto
@@ -11,6 +11,9 @@ service Tasks {
     // Get a single task by name.
     rpc GetTask(GetTaskRequest) returns (Task);
 
+    // List tasks.
+    rpc ListTasks(ListTasksRequest) returns (ListTasksResponse);
+
     // Create a new task.
     rpc CreateTask(CreateTaskRequest) returns (Task);
 
@@ -42,6 +45,25 @@ message GetTaskRequest {
     // The name.
     // Format: tasks/{task}
     string name = 1;
+}
+
+message ListTasksRequest {
+    // The standard page size. Optional. If unspecified, the server will choose
+    // a suitable default. Values larger than 1000 will be truncated to 1000.
+    int32 page_size = 1;
+
+    // The standard page token. Optional. Get the values from responses to
+    // ListTasks.
+    string page_token = 2;
+}
+
+message ListTasksResponse {
+    // The tasks.
+    repeated Task tasks = 1;
+
+    // The token required to get the next page in a subsequent call to
+    // ListTasks.
+    string next_page_token = 2;
 }
 
 message CreateTaskRequest {

--- a/tasks/tasks_go_proto/tasks.pb.go
+++ b/tasks/tasks_go_proto/tasks.pb.go
@@ -158,6 +158,123 @@ func (x *GetTaskRequest) GetName() string {
 	return ""
 }
 
+type ListTasksRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// The standard page size. Optional. If unspecified, the server will choose
+	// a suitable default. Values larger than 1000 will be truncated to 1000.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The standard page token. Optional. Get the values from responses to
+	// ListTasks.
+	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+}
+
+func (x *ListTasksRequest) Reset() {
+	*x = ListTasksRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tasks_tasks_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ListTasksRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTasksRequest) ProtoMessage() {}
+
+func (x *ListTasksRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tasks_tasks_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTasksRequest.ProtoReflect.Descriptor instead.
+func (*ListTasksRequest) Descriptor() ([]byte, []int) {
+	return file_tasks_tasks_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ListTasksRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListTasksRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type ListTasksResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// The tasks.
+	Tasks []*Task `protobuf:"bytes,1,rep,name=tasks,proto3" json:"tasks,omitempty"`
+	// The token required to get the next page in a subsequent call to
+	// ListTasks.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+}
+
+func (x *ListTasksResponse) Reset() {
+	*x = ListTasksResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tasks_tasks_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ListTasksResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTasksResponse) ProtoMessage() {}
+
+func (x *ListTasksResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tasks_tasks_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTasksResponse.ProtoReflect.Descriptor instead.
+func (*ListTasksResponse) Descriptor() ([]byte, []int) {
+	return file_tasks_tasks_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ListTasksResponse) GetTasks() []*Task {
+	if x != nil {
+		return x.Tasks
+	}
+	return nil
+}
+
+func (x *ListTasksResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 type CreateTaskRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -172,7 +289,7 @@ type CreateTaskRequest struct {
 func (x *CreateTaskRequest) Reset() {
 	*x = CreateTaskRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tasks_tasks_proto_msgTypes[2]
+		mi := &file_tasks_tasks_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -185,7 +302,7 @@ func (x *CreateTaskRequest) String() string {
 func (*CreateTaskRequest) ProtoMessage() {}
 
 func (x *CreateTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tasks_tasks_proto_msgTypes[2]
+	mi := &file_tasks_tasks_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -198,7 +315,7 @@ func (x *CreateTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskRequest.ProtoReflect.Descriptor instead.
 func (*CreateTaskRequest) Descriptor() ([]byte, []int) {
-	return file_tasks_tasks_proto_rawDescGZIP(), []int{2}
+	return file_tasks_tasks_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *CreateTaskRequest) GetTask() *Task {
@@ -221,7 +338,7 @@ type DeleteTaskRequest struct {
 func (x *DeleteTaskRequest) Reset() {
 	*x = DeleteTaskRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tasks_tasks_proto_msgTypes[3]
+		mi := &file_tasks_tasks_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -234,7 +351,7 @@ func (x *DeleteTaskRequest) String() string {
 func (*DeleteTaskRequest) ProtoMessage() {}
 
 func (x *DeleteTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tasks_tasks_proto_msgTypes[3]
+	mi := &file_tasks_tasks_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -247,7 +364,7 @@ func (x *DeleteTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTaskRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTaskRequest) Descriptor() ([]byte, []int) {
-	return file_tasks_tasks_proto_rawDescGZIP(), []int{3}
+	return file_tasks_tasks_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DeleteTaskRequest) GetName() string {
@@ -278,17 +395,32 @@ var file_tasks_tasks_proto_rawDesc = []byte{
 	0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x0a, 0x63, 0x72,
 	0x65, 0x61, 0x74, 0x65, 0x54, 0x69, 0x6d, 0x65, 0x22, 0x24, 0x0a, 0x0e, 0x47, 0x65, 0x74, 0x54,
 	0x61, 0x73, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
-	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x34,
+	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x4e,
+	0x0a, 0x10, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x12, 0x1b, 0x0a, 0x09, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x69, 0x7a, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x08, 0x70, 0x61, 0x67, 0x65, 0x53, 0x69, 0x7a, 0x65, 0x12,
+	0x1d, 0x0a, 0x0a, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x09, 0x70, 0x61, 0x67, 0x65, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x22, 0x5e,
+	0x0a, 0x11, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x12, 0x21, 0x0a, 0x05, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x18, 0x01, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x0b, 0x2e, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52,
+	0x05, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x12, 0x26, 0x0a, 0x0f, 0x6e, 0x65, 0x78, 0x74, 0x5f, 0x70,
+	0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x0d, 0x6e, 0x65, 0x78, 0x74, 0x50, 0x61, 0x67, 0x65, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x22, 0x34,
 	0x0a, 0x11, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x65, 0x71, 0x75,
 	0x65, 0x73, 0x74, 0x12, 0x1f, 0x0a, 0x04, 0x74, 0x61, 0x73, 0x6b, 0x18, 0x01, 0x20, 0x01, 0x28,
 	0x0b, 0x32, 0x0b, 0x2e, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x04,
 	0x74, 0x61, 0x73, 0x6b, 0x22, 0x27, 0x0a, 0x11, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x54, 0x61,
 	0x73, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
-	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x32, 0xab, 0x01,
+	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x32, 0xeb, 0x01,
 	0x0a, 0x05, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x12, 0x2d, 0x0a, 0x07, 0x47, 0x65, 0x74, 0x54, 0x61,
 	0x73, 0x6b, 0x12, 0x15, 0x2e, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x2e, 0x47, 0x65, 0x74, 0x54, 0x61,
 	0x73, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x0b, 0x2e, 0x74, 0x61, 0x73, 0x6b,
-	0x73, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x12, 0x33, 0x0a, 0x0a, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65,
+	0x73, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x12, 0x3e, 0x0a, 0x09, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61,
+	0x73, 0x6b, 0x73, 0x12, 0x17, 0x2e, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x2e, 0x4c, 0x69, 0x73, 0x74,
+	0x54, 0x61, 0x73, 0x6b, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18, 0x2e, 0x74,
+	0x61, 0x73, 0x6b, 0x73, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x33, 0x0a, 0x0a, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65,
 	0x54, 0x61, 0x73, 0x6b, 0x12, 0x18, 0x2e, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x2e, 0x43, 0x72, 0x65,
 	0x61, 0x74, 0x65, 0x54, 0x61, 0x73, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x0b,
 	0x2e, 0x74, 0x61, 0x73, 0x6b, 0x73, 0x2e, 0x54, 0x61, 0x73, 0x6b, 0x12, 0x3e, 0x0a, 0x0a, 0x44,
@@ -313,29 +445,34 @@ func file_tasks_tasks_proto_rawDescGZIP() []byte {
 	return file_tasks_tasks_proto_rawDescData
 }
 
-var file_tasks_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_tasks_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_tasks_tasks_proto_goTypes = []interface{}{
 	(*Task)(nil),                  // 0: tasks.Task
 	(*GetTaskRequest)(nil),        // 1: tasks.GetTaskRequest
-	(*CreateTaskRequest)(nil),     // 2: tasks.CreateTaskRequest
-	(*DeleteTaskRequest)(nil),     // 3: tasks.DeleteTaskRequest
-	(*timestamppb.Timestamp)(nil), // 4: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),         // 5: google.protobuf.Empty
+	(*ListTasksRequest)(nil),      // 2: tasks.ListTasksRequest
+	(*ListTasksResponse)(nil),     // 3: tasks.ListTasksResponse
+	(*CreateTaskRequest)(nil),     // 4: tasks.CreateTaskRequest
+	(*DeleteTaskRequest)(nil),     // 5: tasks.DeleteTaskRequest
+	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),         // 7: google.protobuf.Empty
 }
 var file_tasks_tasks_proto_depIdxs = []int32{
-	4, // 0: tasks.Task.create_time:type_name -> google.protobuf.Timestamp
-	0, // 1: tasks.CreateTaskRequest.task:type_name -> tasks.Task
-	1, // 2: tasks.Tasks.GetTask:input_type -> tasks.GetTaskRequest
-	2, // 3: tasks.Tasks.CreateTask:input_type -> tasks.CreateTaskRequest
-	3, // 4: tasks.Tasks.DeleteTask:input_type -> tasks.DeleteTaskRequest
-	0, // 5: tasks.Tasks.GetTask:output_type -> tasks.Task
-	0, // 6: tasks.Tasks.CreateTask:output_type -> tasks.Task
-	5, // 7: tasks.Tasks.DeleteTask:output_type -> google.protobuf.Empty
-	5, // [5:8] is the sub-list for method output_type
-	2, // [2:5] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	6, // 0: tasks.Task.create_time:type_name -> google.protobuf.Timestamp
+	0, // 1: tasks.ListTasksResponse.tasks:type_name -> tasks.Task
+	0, // 2: tasks.CreateTaskRequest.task:type_name -> tasks.Task
+	1, // 3: tasks.Tasks.GetTask:input_type -> tasks.GetTaskRequest
+	2, // 4: tasks.Tasks.ListTasks:input_type -> tasks.ListTasksRequest
+	4, // 5: tasks.Tasks.CreateTask:input_type -> tasks.CreateTaskRequest
+	5, // 6: tasks.Tasks.DeleteTask:input_type -> tasks.DeleteTaskRequest
+	0, // 7: tasks.Tasks.GetTask:output_type -> tasks.Task
+	3, // 8: tasks.Tasks.ListTasks:output_type -> tasks.ListTasksResponse
+	0, // 9: tasks.Tasks.CreateTask:output_type -> tasks.Task
+	7, // 10: tasks.Tasks.DeleteTask:output_type -> google.protobuf.Empty
+	7, // [7:11] is the sub-list for method output_type
+	3, // [3:7] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_tasks_tasks_proto_init() }
@@ -369,7 +506,7 @@ func file_tasks_tasks_proto_init() {
 			}
 		}
 		file_tasks_tasks_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CreateTaskRequest); i {
+			switch v := v.(*ListTasksRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -381,6 +518,30 @@ func file_tasks_tasks_proto_init() {
 			}
 		}
 		file_tasks_tasks_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ListTasksResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tasks_tasks_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CreateTaskRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tasks_tasks_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DeleteTaskRequest); i {
 			case 0:
 				return &v.state
@@ -399,7 +560,7 @@ func file_tasks_tasks_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_tasks_tasks_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/tasks/tasks_go_proto/tasks_grpc.pb.go
+++ b/tasks/tasks_go_proto/tasks_grpc.pb.go
@@ -25,6 +25,8 @@ const _ = grpc.SupportPackageIsVersion7
 type TasksClient interface {
 	// Get a single task by name.
 	GetTask(ctx context.Context, in *GetTaskRequest, opts ...grpc.CallOption) (*Task, error)
+	// List tasks.
+	ListTasks(ctx context.Context, in *ListTasksRequest, opts ...grpc.CallOption) (*ListTasksResponse, error)
 	// Create a new task.
 	CreateTask(ctx context.Context, in *CreateTaskRequest, opts ...grpc.CallOption) (*Task, error)
 	// Delete a task by name.
@@ -42,6 +44,15 @@ func NewTasksClient(cc grpc.ClientConnInterface) TasksClient {
 func (c *tasksClient) GetTask(ctx context.Context, in *GetTaskRequest, opts ...grpc.CallOption) (*Task, error) {
 	out := new(Task)
 	err := c.cc.Invoke(ctx, "/tasks.Tasks/GetTask", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tasksClient) ListTasks(ctx context.Context, in *ListTasksRequest, opts ...grpc.CallOption) (*ListTasksResponse, error) {
+	out := new(ListTasksResponse)
+	err := c.cc.Invoke(ctx, "/tasks.Tasks/ListTasks", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -72,6 +83,8 @@ func (c *tasksClient) DeleteTask(ctx context.Context, in *DeleteTaskRequest, opt
 type TasksServer interface {
 	// Get a single task by name.
 	GetTask(context.Context, *GetTaskRequest) (*Task, error)
+	// List tasks.
+	ListTasks(context.Context, *ListTasksRequest) (*ListTasksResponse, error)
 	// Create a new task.
 	CreateTask(context.Context, *CreateTaskRequest) (*Task, error)
 	// Delete a task by name.
@@ -85,6 +98,9 @@ type UnimplementedTasksServer struct {
 
 func (UnimplementedTasksServer) GetTask(context.Context, *GetTaskRequest) (*Task, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTask not implemented")
+}
+func (UnimplementedTasksServer) ListTasks(context.Context, *ListTasksRequest) (*ListTasksResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTasks not implemented")
 }
 func (UnimplementedTasksServer) CreateTask(context.Context, *CreateTaskRequest) (*Task, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateTask not implemented")
@@ -119,6 +135,24 @@ func _Tasks_GetTask_Handler(srv interface{}, ctx context.Context, dec func(inter
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TasksServer).GetTask(ctx, req.(*GetTaskRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Tasks_ListTasks_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTasksRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TasksServer).ListTasks(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tasks.Tasks/ListTasks",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TasksServer).ListTasks(ctx, req.(*ListTasksRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -169,6 +203,10 @@ var Tasks_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetTask",
 			Handler:    _Tasks_GetTask_Handler,
+		},
+		{
+			MethodName: "ListTasks",
+			Handler:    _Tasks_ListTasks_Handler,
 		},
 		{
 			MethodName: "CreateTask",


### PR DESCRIPTION
Implementing ListTasks means implementing pagination. With pagination, there are
quite a few things that can go wrong. There is lots to read about pagination on
https://google.aip.dev/132 and https://google.aip.dev/158 for more details.

The solution chosen for this simple service is to simply let each task have a
unique, increasing ID. Page tokens are UUIDs that map to a minimum ID to fetch
in the next page. This makes the tokens opaque and protects from the user
tampering with them. At least I think so.

Using a unique, increasing ID means that I changed the resource ID for tasks
from UUIDs to integer IDs. I think this is fine -- revealing the number of tasks
is not very sensitive for this service. After all, this service is only intended
for me to use for some personal stuff, maybe. If that is the case, one might
wonder who the "user" that could tamper with page tokens would be. The answer
is: no-one. But it's a fun exercise in service design to implement it.