### PR TITLE
tasks/service: use the statement builder for all RPCs.

### DIFF
--- a/tasks/service/BUILD.bazel
+++ b/tasks/service/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "@com_github_golang_glog//:glog",
         "@com_github_google_uuid//:uuid",
         "@com_github_jackc_pgx_v4//:pgx",
+        "@com_github_masterminds_squirrel//:squirrel",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/emptypb",


### PR DESCRIPTION
Probably not necessarily needed, but a good way to get 1) consistency and 2)
some experience with this library.