### PR TITLE
bazel: pass absolute path to `make` and `exec`.

### DIFF
--- a/bazel
+++ b/bazel
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-make _tools/bazelisk
-exec _tools/bazelisk "$@"
+make "$(pwd)/_tools/bazelisk"
+exec "$(pwd)/_tools/bazelisk" "$@"


### PR DESCRIPTION
If the `_tools` directory doesn't exist, this script doesn't work because `make`
only knows how to build `/absolute/path/to/_tools/bazelisk`, not
`_tools/bazelisk` relative to the root directory. I always (well, not 100 % of
the time, but 99.99 %) run the `bazel` script from the root directory, so using
`$(pwd)` isn't a very big problem.