### PR TITLE
tasks/fake/server: command to run the fake as a gRPC server.

### DIFF
--- a/tasks/fake/server/BUILD.bazel
+++ b/tasks/fake/server/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "server_lib",
+    srcs = ["server.go"],
+    importpath = "go.saser.se/tasks/fake/server",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//tasks/fake",
+        "//tasks/tasks_go_proto",
+        "@com_github_golang_glog//:glog",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//grpclog/glogger",
+        "@org_golang_google_grpc//reflection",
+    ],
+)
+
+go_binary(
+    name = "server",
+    embed = [":server_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/tasks/fake/server/server.go
+++ b/tasks/fake/server/server.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+
+	"github.com/golang/glog"
+	"go.saser.se/tasks/fake"
+	pb "go.saser.se/tasks/tasks_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	// Imported for side-effects.
+	_ "google.golang.org/grpc/grpclog/glogger"
+)
+
+var port = flag.Int("port", 8080, "The port to serve the gRPC service on.")
+
+func errMain() error {
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	addr := fmt.Sprintf(":%d", *port)
+	glog.Infof("Will open listener on address %q.", addr)
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	glog.Infof("Listening on %q.", addr)
+	defer func() {
+		if err := lis.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			glog.Errorf("Closing listener failed: %v", err)
+		}
+	}()
+
+	srv := grpc.NewServer()
+	f := fake.New()
+	pb.RegisterTasksServer(srv, f)
+	reflection.Register(srv)
+
+	errc := make(chan error, 1)
+	go func() {
+		glog.Infof("Serving gRPC server on %v.", lis.Addr())
+		errc <- srv.Serve(lis)
+	}()
+
+	glog.Info("Waiting for context to be canceled.")
+	<-ctx.Done()
+	glog.Info("Context cancelled, stopping gRPC server...")
+	srv.GracefulStop()
+	glog.Info("gRPC server stopped.")
+	if err := <-errc; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	fmt.Println("hello, world")
+	if err := errMain(); err != nil {
+		glog.Exit(err)
+	}
+}


### PR DESCRIPTION
I consider this to be a starting point for actually running a container
somewhere I can reach it with a client over the network. Running without any
auth etc is probably not a good idea, and someone can probably DoS the server by
spamming lots of `ListTasks` RPCs, but eh, I don't care.