### PR TITLE
tasks/fake/server: create an image that exposes the 8080/tcp port.

### DIFF
--- a/tasks/fake/server/BUILD.bazel
+++ b/tasks/fake/server/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//docker/go:image_with_ports.bzl", "go_image_with_ports")
 
 go_library(
     name = "server_lib",
@@ -19,4 +20,10 @@ go_binary(
     name = "server",
     embed = [":server_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_image_with_ports(
+    name = "server_image",
+    binary=":server",
+    ports = ["8080/tcp"],
 )


### PR DESCRIPTION
In theory, the port can be configured using a command-line flag, but it defaults
to 8080 so let's use that.