### PR TITLE
docker/imagetar: don't load the 360MB Postgres image in testing.

### DIFF
--- a/docker/imagetar/BUILD.bazel
+++ b/docker/imagetar/BUILD.bazel
@@ -8,15 +8,15 @@ container_image(
 )
 
 container_image(
-    name = "testimage_postgres",
-    base = "@postgres_image//image",
+    name = "testimage_hola_mundo",
+    base = "@hello_world_image//image",
 )
 
 container_bundle(
     name = "testbundle",
     images = {
         "bazel/docker/imagetar:testimage_hello_world": ":testimage_hello_world",
-        "bazel/docker/imagetar:testimage_postgres": ":testimage_postgres",
+        "bazel/docker/imagetar:testimage_hola_mundo": ":testimage_hola_mundo",
     },
 )
 

--- a/docker/imagetar/imagetar_test.go
+++ b/docker/imagetar/imagetar_test.go
@@ -78,7 +78,7 @@ func TestRepositories(t *testing.T) {
 			want: map[string]map[string]string{
 				"bazel/docker/imagetar": {
 					"testimage_hello_world": "a5f34025714d147c8ad37b8e237b52af7b58a5f44be46a5e550f0873705d1f24",
-					"testimage_postgres":    "dbb3b0216e75b7d3bdaa1e956da967d6ded3809bd85f3887dbda8f6114868de0",
+					"testimage_hola_mundo":  "a5f34025714d147c8ad37b8e237b52af7b58a5f44be46a5e550f0873705d1f24",
 				},
 			},
 		},
@@ -139,7 +139,7 @@ func TestImages(t *testing.T) {
 			r:    bytes.NewReader(testbundle),
 			want: []string{
 				"bazel/docker/imagetar:testimage_hello_world",
-				"bazel/docker/imagetar:testimage_postgres",
+				"bazel/docker/imagetar:testimage_hola_mundo",
 			},
 		},
 	} {
@@ -148,7 +148,8 @@ func TestImages(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+			lessFunc := func(s1, s2 string) bool { return s1 < s2 }
+			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(lessFunc)); diff != "" {
 				t.Errorf("unexpected result from Images (-want +got)\n%s", diff)
 			}
 		})


### PR DESCRIPTION
This makes it difficult to run this test many times in parallel, because loading
that image eats up a huge amount of memory.