### PR TITLE
Install a Go toolchain using Make.

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -4,8 +4,10 @@
 
 Requirements:
 
+*   `curl`.
 *   `make`.
-*   A Go toolchain (the `go` command must be available).
+*   `tar`.
+*   `unzip`.
 
 This repository uses [`bazelisk`](https://github.com/bazelbuild/bazelisk) to install and run Bazel. In other words, you don't need to install it yourself. `bazelisk` is invoked via a script called `bazel` in the root of the repository.
 
@@ -27,4 +29,5 @@ $ go get -u -t -tags=tools ./... # updates direct tool dependencies, see tools.g
 $ go mod tidy                    # clean up go.mod and go.sum
 $ make generate                  # regenerate code
 $ make fix                       # update repositories.bzl, BUILD files, etc
+$ make fix                       # possibly needed due to non-hermetic code formatters
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 include tools.mk
 
-go_module := $(shell go list -m)
+# This needs to be kept in sync with go.mod.
+#
+# We could try to invike 'go list -m' but we also install the `go` command via
+# Make, which makes it hairy to make sure `go` is available before this is run.
+# Also, the module should change very rarely, so hard-coding the value seems
+# worth the tradeoff.
+go_module := go.saser.se
 
 build_files := $(shell git ls-files -- 'WORKSPACE' '**/BUILD.bazel' '*.bzl')
 go_files := $(shell git ls-files -- '*.go')
@@ -53,7 +59,7 @@ fix-gofumpt:
 		$(go_files)
 
 .PHONY: fix-go-buildfiles
-fix-go-buildfiles:
-	go mod tidy -v
+fix-go-buildfiles: $(go)
+	$(go) mod tidy -v
 	./bazel run //:gazelle_update_repos
 	./bazel run //:gazelle

--- a/tools.mk
+++ b/tools.mk
@@ -8,26 +8,56 @@ tools := $(root)/_tools
 $(tools):
 	mkdir -p '$@'
 
+# go: the Go toolchain.
+# NOTE: this is only installed to be used to install other tools. The Go
+# toolchain used for actually building stuff is pulled down via Bazel and
+# specified in the WORKSPACE file.
+#
+# The version must be kept in sync with the WORKSPACE file.
+go_version := 1.18.4
+go_archive := $(tools)/go_$(go_version).tar.gz
+$(go_archive): | $(tools)
+	curl \
+		--fail \
+		--location \
+		--show-error \
+		--silent \
+		--output '$@' \
+		'https://go.dev/dl/go$(go_version).linux-amd64.tar.gz'
+go_dir := $(tools)/go_$(go_version)
+$(go_dir): $(go_archive)
+	mkdir \
+		--parents \
+		'$@'
+	tar \
+		--extract \
+		--directory '$@' \
+		--gzip \
+		--strip-components 1 \
+		--file '$(go_archive)'
+go := $(go_dir)/bin/go
+$(go): $(go_dir)
+
 # bazelisk: a script to run Bazel with a given version.
 bazelisk := $(tools)/bazelisk
-$(bazelisk): go.mod | $(tools)
-	go \
+$(bazelisk): go.mod $(go) | $(tools)
+	$(go) \
 		build \
 		-o='$@' \
 		github.com/bazelbuild/bazelisk
 
 # buildifier: a formatter and linter for BUILD.bazel files.
 buildifier := $(tools)/buildifier
-$(buildifier): go.mod | $(tools)
-	go \
+$(buildifier): go.mod $(go) | $(tools)
+	$(go) \
 		build \
 		-o='$@' \
 		github.com/bazelbuild/buildtools/buildifier
 
 # gofumpt: a stricter subset of gofmt.
 gofumpt := $(tools)/gofumpt
-$(gofumpt): go.mod | $(tools)
-	go \
+$(gofumpt): go.mod $(go) | $(tools)
+	$(go) \
 		build \
 		-o='$@' \
 		mvdan.cc/gofumpt
@@ -53,16 +83,16 @@ $(protoc): $(protoc_dir)
 
 # protoc-gen-go: the protoc plugin for generating Go code from protobufs.
 protoc-gen-go := $(tools)/protoc-gen-go
-$(protoc-gen-go): go.mod | $(tools)
-	go \
+$(protoc-gen-go): go.mod $(go) | $(tools)
+	$(go) \
 		build \
 		-o='$@' \
 		google.golang.org/protobuf/cmd/protoc-gen-go
 
 # protoc-gen-go-grpc: the protoc plugin for generating gRPC-Go code from protobufs.
 protoc-gen-go-grpc := $(tools)/protoc-gen-go-grpc
-$(protoc-gen-go-grpc): go.mod | $(tools)
-	go \
+$(protoc-gen-go-grpc): go.mod $(go) | $(tools)
+	$(go) \
 		build \
 		-o='$@' \
 		google.golang.org/grpc/cmd/protoc-gen-go-grpc


### PR DESCRIPTION
A Go toolchain is used to install other tools such as `bazelisk` and `protoc`
plugins. Previously, a Go toolchain was required to be installed manually, which
has some drawbacks:

*   The version can differ between machines.
*   It adds an extra implicit dependency to use this repository.

This change pulls down a Go toolchain from the Go website and uses that to build
the aforementioned tools, which results in a more reproducible build.