### PR TITLE
grpctest: package to facilitate testing with real gRPC transports.

### DIFF
--- a/grpctest/BUILD.bazel
+++ b/grpctest/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "grpctest",
+    srcs = ["grpctest.go"],
+    importpath = "go.saser.se/grpctest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//credentials/insecure",
+    ],
+)
+
+go_test(
+    name = "grpctest_test",
+    srcs = ["grpctest_test.go"],
+    embed = [":grpctest"],
+    deps = [
+        "//testing/echo",
+        "//testing/echo_go_proto",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//credentials/insecure",
+    ],
+)

--- a/grpctest/grpctest.go
+++ b/grpctest/grpctest.go
@@ -1,0 +1,68 @@
+// Package grpctest contains utilities for quickly setting up a gRPC server that
+// serves an implementation of a service. The package is intended to make
+// writing unit tests using a real gRPC transport easier.
+package grpctest
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// NewServerAddress starts up a gRPC server, registers the given implementation
+// for the given service description, and returns the address the gRPC server is
+// listening on.
+func NewServerAddress(tb testing.TB, sd *grpc.ServiceDesc, impl any) string {
+	tb.Helper()
+
+	// We use a port number of 0 to let the operating system assign us a port.
+	const listenAddr = "localhost:0"
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		tb.Fatalf("failed to create TCP listener for %q: %v", listenAddr, err)
+	}
+	tb.Cleanup(func() {
+		if err := lis.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			tb.Errorf("failed to close TCP listener for %q: %v", listenAddr, err)
+		}
+	})
+
+	errc := make(chan error, 1)
+	tb.Cleanup(func() {
+		if err := <-errc; err != nil {
+			tb.Errorf("gRPC server failed to serve: %v", err)
+		}
+	})
+
+	srv := grpc.NewServer()
+	srv.RegisterService(sd, impl)
+	go func() {
+		errc <- srv.Serve(lis)
+	}()
+	tb.Cleanup(srv.GracefulStop)
+
+	return lis.Addr().String()
+}
+
+// NewClientConn starts up a gRPC server, with the given implementation
+// registered for the given service description, and returns a gRPC client
+// pointed at that server. NewClientConn does _not_ wait until the client has
+// fully connected before returning.
+func NewClientConn(tb testing.TB, sd *grpc.ServiceDesc, impl any) *grpc.ClientConn {
+	tb.Helper()
+
+	addr := NewServerAddress(tb, sd, impl)
+	cc, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		tb.Fatalf("failed to open gRPC connection to %q: %v", addr, err)
+	}
+	tb.Cleanup(func() {
+		if err := cc.Close(); err != nil {
+			tb.Errorf("failed to close gRPC connection to %q: %v", addr, err)
+		}
+	})
+	return cc
+}

--- a/grpctest/grpctest_test.go
+++ b/grpctest/grpctest_test.go
@@ -1,0 +1,53 @@
+package grpctest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.saser.se/testing/echo"
+	echopb "go.saser.se/testing/echo_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const concurrency = 10_000
+
+// We run these tests with a significant amount of concurrency to try and suss
+// out races w.r.t. picking ports and establishing connections.
+
+func TestNewServerAddress(t *testing.T) {
+	t.Parallel()
+	for i := 0; i < concurrency; i++ {
+		i := i
+		t.Run(fmt.Sprintf("%05d", i), func(t *testing.T) {
+			t.Parallel()
+			addr := NewServerAddress(t, &echopb.Echo_ServiceDesc, echo.Server{})
+			// We must connect to the server because otherwise it will be
+			// stopped before it has even had a chance to start up, failing the
+			// test.
+			_, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				t.Fatalf("failed to connect to %q: %v", addr, err)
+			}
+		})
+	}
+}
+
+func TestNewClientConn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	for i := 0; i < concurrency; i++ {
+		i := i
+		t.Run(fmt.Sprintf("%05d", i), func(t *testing.T) {
+			t.Parallel()
+			cc := NewClientConn(t, &echopb.Echo_ServiceDesc, echo.Server{})
+			client := echopb.NewEchoClient(cc)
+			req := &echopb.EchoRequest{Message: "Hello, grpctest"}
+			if _, err := client.Echo(ctx, req); err != nil {
+				t.Fatalf("[% 5d] Echo(%v) err = %v; want nil", i, req, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This package should make it easier to write more robust tests that exercise the
full gRPC stack by using real gRPC transports.