### PR TITLE
grpctest: drop existing functions and create a Server type instead.

### DIFF
--- a/grpctest/BUILD.bazel
+++ b/grpctest/BUILD.bazel
@@ -40,7 +40,5 @@ go_test(
     deps = [
         "//testing/echo",
         "//testing/echo_go_proto",
-        "@org_golang_google_grpc//:grpc",
-        "@org_golang_google_grpc//credentials/insecure",
     ],
 )

--- a/grpctest/grpctest_test.go
+++ b/grpctest/grpctest_test.go
@@ -4,58 +4,44 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"go.saser.se/testing/echo"
 	echopb "go.saser.se/testing/echo_go_proto"
-	"google.golang.org/grpc"
 )
 
 // We run these tests with a significant amount of concurrency to try and suss
 // out races w.r.t. picking ports and establishing connections.
-const concurrency = 10_000
+const concurrency = 100_000
 
-func TestNewServerAddress(t *testing.T) {
-	t.Parallel()
-
-	// Bugs in the tested code (which includes the code generating the
-	// TLS certificate) generally show up as tests that hang. We set a
-	// short timeout to allow tests to fail quickly if that is the case.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
-
-	for i := 0; i < concurrency; i++ {
-		t.Run(fmt.Sprintf("%05d", i), func(t *testing.T) {
-			t.Parallel()
-			addr := NewServerAddress(t, &echopb.Echo_ServiceDesc, echo.Server{})
-
-			// The goroutine that runs (*grpc.Server).Serve from
-			// NewServerAddress might not even have started before
-			// NewServerAddress returns. If the test finished as soon as
-			// NewServerAddress returned, then the call to Serve will fail,
-			// failing the test. To work around this, we make sure to connect to
-			// the server before finishing the test.
-			creds := clientCredentials(t)
-			_, err := grpc.DialContext(ctx, addr, grpc.WithBlock(), grpc.WithTransportCredentials(creds))
-			if err != nil {
-				t.Fatalf("failed to connect to %q: %v", addr, err)
-			}
-		})
-	}
-}
-
-func TestNewClientConn(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	for i := 0; i < concurrency; i++ {
-		t.Run(fmt.Sprintf("%05d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%06d", i), func(t *testing.T) {
 			t.Parallel()
-			cc := NewClientConn(t, &echopb.Echo_ServiceDesc, echo.Server{})
-			client := echopb.NewEchoClient(cc)
-			req := &echopb.EchoRequest{Message: "Hello, grpctest"}
-			if _, err := client.Echo(ctx, req); err != nil {
-				t.Fatalf("Echo(%v) err = %v; want nil", req, err)
+
+			srv := New(ctx, t, Options{
+				ServiceDesc:    &echopb.Echo_ServiceDesc,
+				Implementation: echo.Server{},
+			})
+
+			if srv.Address == "" {
+				t.Errorf("srv.Addr = %q; want non-empty", srv.Address)
+			}
+			if srv.ClientConn == nil {
+				t.Errorf("srv.Conn = %v; want non-nil", srv.ClientConn)
+			}
+
+			client := echopb.NewEchoClient(srv.ClientConn)
+			const msg = "I'm using servertest"
+			req := &echopb.EchoRequest{Message: msg}
+			res, err := client.Echo(ctx, req)
+			if err != nil {
+				t.Errorf("Echo(%v) err = %v; want nil", req, err)
+			}
+			if got, want := res.GetMessage(), msg; got != want {
+				t.Errorf("Echo(%v) message = %q; want %q", req, got, want)
 			}
 		})
 	}


### PR DESCRIPTION
The Server type will hold everything relevant to the gRPC server started by the
`New` function. It is accompanied by an Options type that holds everything
relevant for configuring the Server. Together, they form a flexible but coherent
API.