### PR TITLE
Run as many tests as possible using t.Parallel.

### DIFF
--- a/docker/dockertest/dockertest_test.go
+++ b/docker/dockertest/dockertest_test.go
@@ -12,6 +12,7 @@ const (
 )
 
 func TestLoad(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	if got, want := Load(ctx, t, helloWorld), "bazel/docker/dockertest:hello_world_image"; got != want {
 		t.Errorf("Load(%q) = %q; want %q", helloWorld, got, want)
@@ -19,6 +20,7 @@ func TestLoad(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	opts := RunOptions{
 		Image: Load(ctx, t, helloWorld),
@@ -32,6 +34,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestAddress(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	opts := RunOptions{
 		Image: Load(ctx, t, postgres),

--- a/docker/imagetar/imagetar_test.go
+++ b/docker/imagetar/imagetar_test.go
@@ -58,6 +58,7 @@ func replaceFile(t *testing.T, archive []byte, name string, contents []byte) []b
 }
 
 func TestRepositories(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name string
 		r    io.Reader
@@ -83,7 +84,9 @@ func TestRepositories(t *testing.T) {
 			},
 		},
 	} {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := Repositories(tt.r)
 			if err != nil {
 				t.Fatal(err)
@@ -96,6 +99,7 @@ func TestRepositories(t *testing.T) {
 }
 
 func TestRepositories_Error(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name string
 		r    io.Reader
@@ -112,7 +116,9 @@ func TestRepositories_Error(t *testing.T) {
 			want: ErrRepositoriesInvalid,
 		},
 	} {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, got := Repositories(tt.r)
 			if diff := cmp.Diff(tt.want, got, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("unexpected error from Repositories (-want +got)\n%s", diff)
@@ -122,6 +128,7 @@ func TestRepositories_Error(t *testing.T) {
 }
 
 func TestImages(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name string
 		r    io.Reader
@@ -143,6 +150,7 @@ func TestImages(t *testing.T) {
 			},
 		},
 	} {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Images(tt.r)
 			if err != nil {
@@ -157,6 +165,7 @@ func TestImages(t *testing.T) {
 }
 
 func TestImages_Error(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name string
 		r    io.Reader
@@ -173,7 +182,9 @@ func TestImages_Error(t *testing.T) {
 			want: ErrRepositoriesInvalid,
 		},
 	} {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, got := Images(tt.r)
 			if diff := cmp.Diff(tt.want, got, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("unexpected error from Images (-want +got)\n%s", diff)

--- a/postgres/postgrestest/postgrestest_test.go
+++ b/postgres/postgrestest/postgrestest_test.go
@@ -9,6 +9,7 @@ import (
 const schemaPath = "postgres/postgrestest/schema.sql"
 
 func TestOpen(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := Open(ctx, t, schemaPath)
 	sql := strings.TrimSpace(`

--- a/runfiles/runfiles_test.go
+++ b/runfiles/runfiles_test.go
@@ -13,6 +13,7 @@ const (
 )
 
 func TestPath(t *testing.T) {
+	t.Parallel()
 	path, err := Path(testfile)
 	if err != nil {
 		t.Fatalf("Path(%q) err = %v; want nil", testfile, err)
@@ -25,6 +26,7 @@ func TestPath(t *testing.T) {
 }
 
 func TestPath_Error(t *testing.T) {
+	t.Parallel()
 	got, err := Path(doesNotExist)
 	if err == nil {
 		t.Errorf("Path(%q) err = nil; want non-nil", doesNotExist)
@@ -35,6 +37,7 @@ func TestPath_Error(t *testing.T) {
 }
 
 func TestPathT(t *testing.T) {
+	t.Parallel()
 	path := PathT(t, testfile)
 	// We can't assert much about the path -- it's too "workstation-dependent".
 	// It should _probably_ be an absolute path, though.
@@ -44,6 +47,7 @@ func TestPathT(t *testing.T) {
 }
 
 func TestMustPath(t *testing.T) {
+	t.Parallel()
 	path := MustPath(testfile)
 	// We can't assert much about the path -- it's too "workstation-dependent".
 	// It should _probably_ be an absolute path, though.
@@ -53,6 +57,7 @@ func TestMustPath(t *testing.T) {
 }
 
 func TestMustPath_Panic(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if err := recover(); err == nil {
 			t.Errorf("MustPath(%q) either did not panic or panicked with nil argument", doesNotExist)
@@ -62,6 +67,7 @@ func TestMustPath_Panic(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
+	t.Parallel()
 	f, err := Open(testfile)
 	if err != nil {
 		t.Fatalf("Open(%q) err = %v; want nil", testfile, err)
@@ -82,6 +88,7 @@ func TestOpen(t *testing.T) {
 }
 
 func TestOpen_Error(t *testing.T) {
+	t.Parallel()
 	f, err := Open(doesNotExist)
 	if err == nil {
 		t.Errorf("Open(%q) err = nil; want non-nil", doesNotExist)
@@ -92,6 +99,7 @@ func TestOpen_Error(t *testing.T) {
 }
 
 func TestOpenT(t *testing.T) {
+	t.Parallel()
 	f := OpenT(t, testfile)
 	got, err := io.ReadAll(f)
 	if err != nil {
@@ -104,6 +112,7 @@ func TestOpenT(t *testing.T) {
 }
 
 func TestMustOpen(t *testing.T) {
+	t.Parallel()
 	f := MustOpen(testfile)
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -113,6 +122,7 @@ func TestMustOpen(t *testing.T) {
 }
 
 func TestMustOpen_Panic(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if err := recover(); err == nil {
 			t.Errorf("MustOpen(%q) either did not panic or panicked with nil argument", doesNotExist)
@@ -122,6 +132,7 @@ func TestMustOpen_Panic(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
+	t.Parallel()
 	got, err := Read(testfile)
 	if err != nil {
 		t.Fatalf("Read(%q) err = %v; want nil", testfile, err)
@@ -133,6 +144,7 @@ func TestRead(t *testing.T) {
 }
 
 func TestRead_Error(t *testing.T) {
+	t.Parallel()
 	got, err := Read(doesNotExist)
 	if err == nil {
 		t.Errorf("Read(%q) err = nil; want non-nil", doesNotExist)
@@ -143,6 +155,7 @@ func TestRead_Error(t *testing.T) {
 }
 
 func TestReadT(t *testing.T) {
+	t.Parallel()
 	got := ReadT(t, testfile)
 	want := []byte("This is an example file to be used in tests.\n")
 	if !bytes.Equal(got, want) {
@@ -151,6 +164,7 @@ func TestReadT(t *testing.T) {
 }
 
 func TestMustRead(t *testing.T) {
+	t.Parallel()
 	got := MustRead(testfile)
 	want := []byte("This is an example file to be used in tests.\n")
 	if !bytes.Equal(got, want) {
@@ -159,6 +173,7 @@ func TestMustRead(t *testing.T) {
 }
 
 func TestMustRead_Panic(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if err := recover(); err == nil {
 			t.Errorf("MustRead(%q) either did not panic or panicked with nil argument", doesNotExist)


### PR DESCRIPTION
I don't think this decreases the runtime anything, but it's a good practice to
use t.Parallel by default; it can help suss out subtle concurrency bugs, or
tests that depend on being run in a certain order.