### PR TITLE
auth: add HTTP Basic authentication.

### DIFF
--- a/auth/BUILD.bazel
+++ b/auth/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "auth",
+    srcs = ["auth.go"],
+    importpath = "go.saser.se/auth",
+    visibility = ["//visibility:public"],
+)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,7 @@
+// Package auth provides some common functionality for implementing
+// authentication and authorization in gRPC services.
+package auth
+
+// MetadataKey is the canonical key in gRPC metadata where
+// authentication/authorization data is stored.
+const MetadataKey = "authorization"

--- a/auth/n/basic/BUILD.bazel
+++ b/auth/n/basic/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "basic",
+    srcs = [
+        "credentials.go",
+        "doc.go",
+        "interceptor.go",
+    ],
+    importpath = "go.saser.se/auth/n/basic",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//auth",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "basic_test",
+    srcs = [
+        "credentials_test.go",
+        "interceptor_test.go",
+    ],
+    embed = [":basic"],
+    deps = [
+        "//auth",
+        "//grpctest",
+        "//testing/echo",
+        "//testing/echo_go_proto",
+        "@com_github_google_go_cmp//cmp",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/auth/n/basic/credentials.go
+++ b/auth/n/basic/credentials.go
@@ -1,0 +1,108 @@
+package basic
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.saser.se/auth"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+)
+
+// Credentials contains the username and password supplied in a request using
+// HTTP Basic authentication. Credentials is to be used for per-RPC credentials
+// in gRPC.
+type Credentials struct {
+	Username string
+	Password string
+}
+
+var _ credentials.PerRPCCredentials = Credentials{}
+
+// Parse takes a string of the format "Basic base64(username:password)" and
+// parses it into Credentials.
+func Parse(s string) (Credentials, error) {
+	formatErr := fmt.Errorf("basic: credentials do not match expected format %q", "Basic base64(<username>:<password>)")
+
+	kind, encoded, found := strings.Cut(s, " ")
+	if !found {
+		return Credentials{}, formatErr
+	}
+	if kind != "Basic" {
+		return Credentials{}, formatErr
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return Credentials{}, formatErr
+	}
+
+	username, password, found := strings.Cut(string(decoded), ":")
+	if !found {
+		return Credentials{}, formatErr
+	}
+
+	return Credentials{
+		Username: username,
+		Password: password,
+	}, nil
+}
+
+func FromIncomingContext(ctx context.Context) (Credentials, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return Credentials{}, errors.New("basic: no metadata in incoming context")
+	}
+	values := md.Get(auth.MetadataKey)
+	if got, want := len(values), 1; got != want {
+		return Credentials{}, fmt.Errorf("basic: metadata key %q has %d values; want exactly %d", auth.MetadataKey, got, want)
+	}
+
+	formatErr := fmt.Errorf("basic: metadata key %q does not have expected format %q", auth.MetadataKey, "Basic base64(<username>:<password>)")
+
+	kind, encoded, found := strings.Cut(values[0], " ")
+	if !found {
+		return Credentials{}, formatErr
+	}
+	if kind != "Basic" {
+		return Credentials{}, formatErr
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return Credentials{}, formatErr
+	}
+
+	username, password, found := strings.Cut(string(decoded), ":")
+	if !found {
+		return Credentials{}, formatErr
+	}
+
+	return Credentials{
+		Username: username,
+		Password: password,
+	}, nil
+}
+
+// HeaderValue encodes the credentials into the form expected by HTTP headers
+// and gRPC metadata, namely:
+//
+//	Basic base64(username:password)
+func (c Credentials) HeaderValue() string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(c.Username+":"+c.Password))
+}
+
+// GetRequestMetadata returns a map containing the authorization key (see
+// auth.MetadataKey) with a value of c.HeaderValue().
+func (c Credentials) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{
+		auth.MetadataKey: c.HeaderValue(),
+	}, nil
+}
+
+// RequireTransportSecurity always returns yes -- HTTP Basic authentication is
+// completely insecure without transport security (like HTTPS).
+func (c Credentials) RequireTransportSecurity() bool { return true }

--- a/auth/n/basic/credentials_test.go
+++ b/auth/n/basic/credentials_test.go
@@ -1,0 +1,196 @@
+package basic
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.saser.se/auth"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		s    string
+		want Credentials
+	}{
+		{
+			name: "UsernameAndPassword",
+			s:    "Basic YWxpY2U6c29tZXBhc3N3b3Jk",
+			want: Credentials{
+				Username: "alice",
+				Password: "somepassword",
+			},
+		},
+		{
+			name: "EmptyUsername",
+			s:    "Basic OnNvbWVwYXNzd29yZA==",
+			want: Credentials{
+				Username: "",
+				Password: "somepassword",
+			},
+		},
+		{
+			name: "EmptyPassword",
+			s:    "Basic YWxpY2U6",
+			want: Credentials{
+				Username: "alice",
+				Password: "",
+			},
+		},
+		{
+			name: "EmptyUsernameAndPassword",
+			s:    "Basic Og==",
+			want: Credentials{
+				Username: "",
+				Password: "",
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(tt.s)
+			if err != nil {
+				t.Fatalf("Parse(%q) err = %v; want nil", tt.s, err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Unexpected result of Parse (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParse_Error(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		s    string
+	}{
+		{
+			name: "WrongKind",
+			s:    "Bearer YWxpY2U6c29tZXBhc3N3b3Jk",
+		},
+		{
+			name: "NoKind",
+			s:    "OnNvbWVwYXNzd29yZA==",
+		},
+		{
+			name: "NotEncoded",
+			s:    "Basic alice:password",
+		},
+		{
+			name: "Empty",
+			s:    "",
+		},
+		{
+			name: "NoColon",
+			s:    "Basic YWxpY2VwYXNzd29yZA==", // base64("alicepassword")
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Parse(tt.s); err == nil {
+				t.Fatalf("Parse(%q) err = nil; want non-nil", tt.s)
+			}
+		})
+	}
+}
+
+func TestParse_Roundtrip(t *testing.T) {
+	t.Parallel()
+	for _, c := range []Credentials{
+		{Username: "alice", Password: "super secret password"},
+		{Username: "", Password: "super secret password"},
+		{Username: "alice", Password: ""},
+		{Username: "", Password: ""},
+	} {
+		s := c.HeaderValue()
+		got, err := Parse(s)
+		if err != nil {
+			t.Errorf("Parse(%q) err = %v; want nil", s, err)
+		}
+		if diff := cmp.Diff(c, got); diff != "" {
+			t.Errorf("Unexpected diff from roundtripping (-want +got)\n%s", diff)
+		}
+	}
+}
+
+func TestCredentials_HeaderValue(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		c    Credentials
+		want string
+	}{
+		{
+			name: "UsernameAndPassword",
+			c: Credentials{
+				Username: "alice",
+				Password: "somepassword",
+			},
+			want: "Basic YWxpY2U6c29tZXBhc3N3b3Jk",
+		},
+		{
+			name: "EmptyUsername",
+			c: Credentials{
+				Username: "",
+				Password: "somepassword",
+			},
+			want: "Basic OnNvbWVwYXNzd29yZA==",
+		},
+		{
+			name: "EmptyPassword",
+			c: Credentials{
+				Username: "alice",
+				Password: "",
+			},
+			want: "Basic YWxpY2U6",
+		},
+		{
+			name: "EmptyUsernameAndPassword",
+			c: Credentials{
+				Username: "",
+				Password: "",
+			},
+			want: "Basic Og==",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got, want := tt.c.HeaderValue(), tt.want; got != want {
+				t.Errorf("(%#v).String() = %q; want %q", tt.c, got, want)
+			}
+		})
+	}
+}
+
+func TestCredentials_GetRequestMetadata(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		username = "alice"
+		password = "super secret"
+	)
+
+	want := map[string]string{
+		auth.MetadataKey: "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
+	}
+
+	creds := Credentials{
+		Username: username,
+		Password: password,
+	}
+	got, err := creds.GetRequestMetadata(ctx)
+	if err != nil {
+		t.Fatalf("GetRequestMetadata() err = %v; want nil", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unexpected diff in request metadata (-want +got)\n%s", diff)
+	}
+}

--- a/auth/n/basic/doc.go
+++ b/auth/n/basic/doc.go
@@ -1,0 +1,3 @@
+// Package basic provides functionality for doing HTTP Basic authentication
+// (username and password supplied on every request) in gRPC.
+package basic

--- a/auth/n/basic/interceptor.go
+++ b/auth/n/basic/interceptor.go
@@ -1,0 +1,49 @@
+package basic
+
+import (
+	"context"
+	"errors"
+
+	"go.saser.se/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func Interceptor(username string, password string) (grpc.UnaryServerInterceptor, error) {
+	if username == "" {
+		return nil, errors.New("basic: interceptor: empty username")
+	}
+	if password == "" {
+		return nil, errors.New("basic: interceptor: empty password")
+	}
+
+	interceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "basic: no metadata in incoming context")
+		}
+		values := md.Get(auth.MetadataKey)
+		if got, want := len(values), 1; got != want {
+			return nil, status.Errorf(codes.Unauthenticated, "basic: metadata key %q has %d values; want exactly %d", auth.MetadataKey, got, want)
+		}
+
+		creds, err := Parse(values[0])
+		if err != nil {
+			return nil, status.Errorf(codes.Unauthenticated, "basic: metadata key %q does not have expected format %q", auth.MetadataKey, "Basic base64(username:password)")
+		}
+
+		if creds.Username == "" {
+			return nil, status.Error(codes.Unauthenticated, "basic: credentials contains empty username")
+		}
+		if creds.Password == "" {
+			return nil, status.Error(codes.Unauthenticated, "basic: credentials contains empty password")
+		}
+		if creds.Username != username || creds.Password != password {
+			return nil, status.Error(codes.Unauthenticated, "basic: credentials contain mismatched username and password")
+		}
+		return handler(ctx, req)
+	}
+	return interceptor, nil
+}

--- a/auth/n/basic/interceptor_test.go
+++ b/auth/n/basic/interceptor_test.go
@@ -1,0 +1,103 @@
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"go.saser.se/grpctest"
+	"go.saser.se/testing/echo"
+	echopb "go.saser.se/testing/echo_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestInterceptor(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		username = "alice"
+		password = "super secret"
+	)
+
+	i, err := Interceptor(username, password)
+	if err != nil {
+		t.Fatalf("Interceptor(%q, %q) err = %v; want nil", username, password, err)
+	}
+	srv := grpctest.New(ctx, t, grpctest.Options{
+		ServiceDesc:    &echopb.Echo_ServiceDesc,
+		Implementation: echo.Server{},
+
+		ServerOptions: []grpc.ServerOption{
+			grpc.UnaryInterceptor(i),
+		},
+	})
+
+	for _, tt := range []struct {
+		name  string
+		creds Credentials
+		want  codes.Code
+	}{
+		{
+			name: "OK",
+			creds: Credentials{
+				Username: username,
+				Password: password,
+			},
+			want: codes.OK,
+		},
+		{
+			name: "EmptyUsername",
+			creds: Credentials{
+				Username: "",
+				Password: password,
+			},
+			want: codes.Unauthenticated,
+		},
+		{
+			name: "EmptyPassword",
+			creds: Credentials{
+				Username: username,
+				Password: "",
+			},
+			want: codes.Unauthenticated,
+		},
+		{
+			name: "WrongUsername",
+			creds: Credentials{
+				Username: "bob",
+				Password: password,
+			},
+			want: codes.Unauthenticated,
+		},
+		{
+			name: "WrongPassword",
+			creds: Credentials{
+				Username: username,
+				Password: "this is wrong",
+			},
+			want: codes.Unauthenticated,
+		},
+		{
+			name: "WrongUsernameAndPassword",
+			creds: Credentials{
+				Username: "bob",
+				Password: "this is wrong",
+			},
+			want: codes.Unauthenticated,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := echopb.NewEchoClient(srv.ClientConn)
+			req := &echopb.EchoRequest{Message: "This needs authentication"}
+			_, err := client.Echo(ctx, req, grpc.PerRPCCredentials(tt.creds))
+			if got, want := status.Code(err), tt.want; got != want {
+				t.Errorf("creds = %+v; Echo(%v) err = %v; want code %v", tt.creds, req, err, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
HTTP Basic authentication means sending username and password on every request.
This is very simple and works well for simple purposes when combined with HTTPS.

The authentication is implemented as a basic.Credentials type, which satisfies
the credentials.PerRPCCredentials interface, and a basic.Interceptor that can be
used server-side to verify incoming basic.Credentials.