### PR TITLE
tasks/server: fix broken logging statement.

### DIFF
--- a/tasks/server/server.go
+++ b/tasks/server/server.go
@@ -37,7 +37,7 @@ func errmain() error {
 	port := *portFlag
 	if port < 0 {
 		envPort := os.Getenv("PORT")
-		glog.Infof("Flag -port=%d is negative; using the environment variable PORT=%q instead", envPort)
+		glog.Infof("Flag -port=%d is negative; using the environment variable PORT=%q instead", port, envPort)
 		var err error
 		port, err = strconv.Atoi(envPort)
 		if err != nil {


### PR DESCRIPTION
It's unfortunate that gopls (or some other tool used in Visual Studio Code)
doesn't detect these errors for the glog package. It does for things like the
standard log package, or t.Errorf, or fmt.Errorf.