### PR TITLE
gcp: a directory to hold GCP-related constants and utilities.

### DIFF
--- a/gcp/.gitignore
+++ b/gcp/.gitignore
@@ -1,0 +1,1 @@
+constants.bzl

--- a/gcp/BUILD.bazel
+++ b/gcp/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "gcp_test",
+    srcs = ["gcp_test.go"],
+    data = [
+        "constants.bzl",
+        "constants.bzl.template",
+    ],
+    deps = [
+        "//runfiles",
+        "@com_github_golang_glog//:glog",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+    ],
+)

--- a/gcp/constants.bzl.template
+++ b/gcp/constants.bzl.template
@@ -1,0 +1,27 @@
+"""constants.bzl: constants to define the GCP environment."""
+
+###############################################################################
+# NOTE: make a copy of this file in the same directory. Call it "constants.bzl"
+# and fill in the values asked for below. That file can contain "secret" or
+# environment-specific configuration and should _not_ be submitted to version
+# control. There is a .gitignore entry to prevent that from happening.
+###############################################################################
+
+# The code and configuration in this repository assumes that there is almost
+# always only _one_ of various entities in GCP:
+# * One project and therefore one project ID.
+# * One region in which stuff runs.
+# * One Artifact Registry repository for Docker images.
+# ... and so on.
+#
+# This file is intended to hold constants defining the GCP "environment" that
+# the rest of the repository uses.
+
+# The project ID of the project containing all resources.
+PROJECT_ID = "PLACEHOLDER_VALUE"
+
+# The region in which resources exist.
+REGION = "PLACEHOLDER_VALUE"
+
+# The name of the Artifact Registry repository for Docker images.
+DOCKER_REPOSITORY = "PLACEHOLDER_VALUE"

--- a/gcp/gcp_test.go
+++ b/gcp/gcp_test.go
@@ -1,0 +1,94 @@
+package gcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/golang/glog"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.saser.se/runfiles"
+)
+
+// constantDeclaration represents a "CONSTANT = <value>" declaration in
+// Starlark.
+type constantDeclaration struct {
+	Line  int
+	Name  string
+	Value string
+}
+
+// parseConstants is a crude Starlark parser that only accepts constants of the form:
+//
+//	CONSTANT = <value>
+//
+// It returns a map from constant name to its corresponding declaration, or an
+// error if it cannot parse the given Starlark code.
+func parseConstants(bzl string) (map[string]constantDeclaration, error) {
+	decls := make(map[string]constantDeclaration)
+	for i, line := range strings.Split(bzl, "\n") {
+		lineNumber := i + 1
+		// We don't care about leading or trailing spaces.
+		line = strings.TrimSpace(line)
+		// If the line is empty, skip it.
+		if line == "" {
+			continue
+		}
+		// If the first character (after trimming spaces) is a '#' or a '"', we
+		// assume it's either a comment or a docstring so we skip it.
+		if c := line[0]; c == '#' || c == '"' {
+			glog.V(1).Infof("Assuming line %d is a comment: %q", lineNumber, line)
+			continue
+		}
+		// We assume the line looks like this:
+		// CONSTANT = <value>
+		// with any number of spaces surrounding the '=' character.
+		name, value, found := strings.Cut(line, "=")
+		if !found {
+			return nil, fmt.Errorf("line %d doesn't follow format %q: %q", lineNumber, "CONSTANT = <value>", line)
+		}
+		name = strings.TrimSpace(name)
+		value = strings.TrimSpace(value)
+		if d, exists := decls[name]; exists {
+			return nil, fmt.Errorf("line %d defines %q, already defined as %q = %q on line %d", lineNumber, name, d.Name, d.Value, d.Line)
+		}
+		decls[name] = constantDeclaration{
+			Line:  lineNumber,
+			Name:  name,
+			Value: value,
+		}
+	}
+	return decls, nil
+}
+
+// TestConstants attempts to verify that the contents of the constants.bzl file
+// (not submitted to source control) matches what is in the template.
+func TestConstants(t *testing.T) {
+	t.Parallel()
+	templateConstants, err := parseConstants(string(runfiles.ReadT(t, "gcp/constants.bzl.template")))
+	if err != nil {
+		t.Fatalf("couldn't parse constants.bzl.template: %v", err)
+	}
+	realConstants, err := parseConstants(string(runfiles.ReadT(t, "gcp/constants.bzl")))
+	if err != nil {
+		t.Fatalf("couldn't parse constants.bzl: %v", err)
+	}
+
+	// Verify that all constants in the template are defined, and that no other
+	// constants are defined.
+	template := mapKeys(templateConstants)
+	real := mapKeys(realConstants)
+	less := func(s1, s2 string) bool { return s1 < s2 }
+	if diff := cmp.Diff(template, real, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("Unexpected diff between defined constant names (-template +real)\n%s", diff)
+	}
+}
+
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	var keys []K
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
I intend to eventually use this to write more BUILD macros that make sure I push
container images to the right places and stuff.

This also includes a test to help verify that the constants.bzl file is up to
date with the latest changes to the template file.