### PR TITLE
docker/config: client configuration for Docker rules.

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -31,3 +31,12 @@ $ make generate                  # regenerate code
 $ make fix                       # update repositories.bzl, BUILD files, etc
 $ make fix                       # possibly needed due to non-hermetic code formatters
 ```
+
+## Regenerate `config.json` for Docker
+
+```shell
+$ ./bazel build //docker/config:generated_config.json
+$ cp \
+    bazel-bin/docker/config/generated_config.json \
+    docker/config/config.json
+```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,6 +39,13 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
 
+load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl", docker_toolchain_configure = "toolchain_configure")
+
+docker_toolchain_configure(
+    name = "docker_config",
+    client_config = "//docker/config:config.json",
+)
+
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
 
 container_repositories()

--- a/docker/config/.gitignore
+++ b/docker/config/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/docker/config/BUILD.bazel
+++ b/docker/config/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//gcp:constants.bzl", "REGION")
+
+# NOTE: the config.json file must be generated since it is not stored in version
+# control. The genrule below can be used to generate the config.json file, but
+# it must then be manually copied in place. To do so, execute the following
+# (assuming working directory is the root of this repository):
+#
+#     $ ./bazel build //docker/config:generated_config.json
+#     $ cp bazel-bin/docker/config/generated_config.json docker/config/config.json
+
+genrule(
+    name = "generated_config_json",
+    outs = ["generated_config.json"],
+    cmd = " ".join([
+        "$(location //docker/config/generate_config)",
+        '-region="{REGION}"'.format(REGION = REGION),
+        '-output="$(location generated_config.json)"',
+    ]),
+    exec_tools = ["//docker/config/generate_config"],
+)

--- a/docker/config/generate_config/BUILD.bazel
+++ b/docker/config/generate_config/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "generate_config_lib",
+    srcs = ["generate_config.go"],
+    embedsrcs = ["config.json.template"],
+    importpath = "go.saser.se/docker/config/generate_config",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_golang_glog//:glog"],
+)
+
+go_binary(
+    name = "generate_config",
+    embed = [":generate_config_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/docker/config/generate_config/config.json.template
+++ b/docker/config/generate_config/config.json.template
@@ -1,0 +1,5 @@
+{
+    "credHelpers": {
+        "{{.Region}}-docker.pkg.dev": "gcloud"
+    }
+}

--- a/docker/config/generate_config/generate_config.go
+++ b/docker/config/generate_config/generate_config.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"text/template"
+
+	"github.com/golang/glog"
+
+	// For embedding the template.
+	_ "embed"
+)
+
+var (
+	region = flag.String("region", "", "GCP region.")
+	output = flag.String("output", "", "Path to write the generated file to.")
+)
+
+var (
+	//go:embed config.json.template
+	rawConfigTemplate string
+	configTemplate    = template.Must(template.New("config.json").Parse(string(rawConfigTemplate)))
+)
+
+type configTemplateParameters struct {
+	Region string
+}
+
+func errmain() error {
+	flag.Parse()
+
+	if *region == "" {
+		return errors.New("-region is empty")
+	}
+	if *output == "" {
+		return errors.New("-output is empty")
+	}
+
+	params := configTemplateParameters{
+		Region: *region,
+	}
+	var buf bytes.Buffer
+	if err := configTemplate.Execute(&buf, params); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	if err := os.WriteFile(*output, buf.Bytes(), fs.FileMode(0o644)); err != nil {
+		return fmt.Errorf("failed to write output file: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := errmain(); err != nil {
+		glog.Exit(err)
+	}
+}


### PR DESCRIPTION
This will eventually be used to push container images to GCP. The `gcloud`
command line tool can be used to authenticate the Docker client, and the
`config.json` file is the way to do it. But since that contains details about
the GCP environment, it needs to be generated and then _not_ stored in version
control.

It's a bit of a convoluted setup but it's a good way to prevent myself from
shooting myself in the foot by committing things to this repository that I later
might decide should be considered "secret" information.