### PR TITLE
tasks/server: add `glogger` as gRPC logger.

### DIFF
--- a/tasks/server/BUILD.bazel
+++ b/tasks/server/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//tasks/tasks_go_proto",
         "@com_github_golang_glog//:glog",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//grpclog/glogger",
     ],
 )
 

--- a/tasks/server/server.go
+++ b/tasks/server/server.go
@@ -19,6 +19,9 @@ import (
 	"go.saser.se/tasks/service"
 	pb "go.saser.se/tasks/tasks_go_proto"
 	"google.golang.org/grpc"
+
+	// Imported for side-effects.
+	_ "google.golang.org/grpc/grpclog/glogger"
 )
 
 var (


### PR DESCRIPTION
Probably good to have as much as possible logging through glog.