### PR TITLE
tasks/server: add flags for optionally serving with TLS.

### DIFF
--- a/tasks/server/BUILD.bazel
+++ b/tasks/server/BUILD.bazel
@@ -14,6 +14,8 @@ go_library(
         "//tasks/tasks_go_proto",
         "@com_github_golang_glog//:glog",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//grpclog/glogger",
     ],
 )


### PR DESCRIPTION
This will be helpful in the future when I'm testing with a local client, such as a TUI, where I will need to use a test-only TLS cert because the basic.Credentials type requires it.