### PR TITLE
Bump Go version to 1.19.1.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "16e9fca53ed6bd4ff4ad76facc9b7b651a89db1689a2877d6fd7b82aa824e366",
+    sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
     ],
 )
 
@@ -29,7 +29,7 @@ go_repositories()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.18.3")
+go_register_toolchains(version = "1.19.1")
 
 gazelle_dependencies()
 

--- a/docker/imagetar/imagetar.go
+++ b/docker/imagetar/imagetar.go
@@ -25,7 +25,7 @@ var (
 // structed as follows to match the definition of the "repositories" file as
 // described at https://docs.docker.com/engine/api/v1.41/#operation/ImageGet.
 //
-//     repository -> tag -> layer ID
+//	repository -> tag -> layer ID
 //
 // If no "repositories" file is found, Repositories returns
 // ErrRepositoriesNotFound. If the file is found but its contents cannot be

--- a/tools.mk
+++ b/tools.mk
@@ -14,7 +14,7 @@ $(tools):
 # specified in the WORKSPACE file.
 #
 # The version must be kept in sync with the WORKSPACE file.
-go_version := 1.18.4
+go_version := 1.19.1
 go_archive := $(tools)/go_$(go_version).tar.gz
 $(go_archive): | $(tools)
 	curl \


### PR DESCRIPTION
We're also taking this opportunity to bump Go-related tools, such as rules_go.