### PR TITLE
grpctest: decrease concurrency in unit test.

### DIFF
--- a/grpctest/grpctest_test.go
+++ b/grpctest/grpctest_test.go
@@ -12,7 +12,7 @@ import (
 
 // We run these tests with a significant amount of concurrency to try and suss
 // out races w.r.t. picking ports and establishing connections.
-const concurrency = 100_000
+const concurrency = 10_000
 
 func TestNew(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
100k goroutines made the test painfully slow to run (>30 seconds). Having 10k is still plenty to find the most glaring race conditions, but now it runs 10x faster.