### PR TITLE
docker/dockertest: use a simple HTTP server instead of Postgres in tests.

### DIFF
--- a/docker/dockertest/BUILD.bazel
+++ b/docker/dockertest/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     srcs = ["dockertest_test.go"],
     data = [
         "hello_world_image.tar",
-        "//postgres:image.tar",
+        "//docker/dockertest/httpserver:httpserver_image.tar",
     ],
     embed = [":dockertest"],
 )

--- a/docker/dockertest/httpserver/BUILD.bazel
+++ b/docker/dockertest/httpserver/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//docker/go:image_with_ports.bzl", "go_image_with_ports")
+
+go_library(
+    name = "httpserver_lib",
+    srcs = ["main.go"],
+    importpath = "go.saser.se/docker/dockertest/httpserver",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "httpserver",
+    embed = [":httpserver_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_image_with_ports(
+    name = "httpserver_image",
+    binary = ":httpserver",
+    ports = ["8080/tcp"],
+    visibility = ["//visibility:public"],
+)

--- a/docker/dockertest/httpserver/main.go
+++ b/docker/dockertest/httpserver/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(w, "Hello, world!")
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Previously the test would pass when run in isolation, but often fail when running with e.g. `--runs_per_test=100`. Which is weird, because the test should never have passed -- we started the Postgres container the wrong way by not supplying the environment variable `POSTGRES_PASSWORD`.

To fix both of these issues the test now uses a simple HTTP server returning "Hello, World!".