### PR TITLE
tasks: fix all mentions of `expiry`.

### DIFF
--- a/tasks/fake/fake.go
+++ b/tasks/fake/fake.go
@@ -225,7 +225,7 @@ func (f *Fake) ListTasks(ctx context.Context, req *pb.ListTasksRequest) (*pb.Lis
 	res := &pb.ListTasksResponse{}
 	for idx := minIndex; idx < len(f.tasks) && len(res.GetTasks()) <= int(pageSize); idx++ {
 		task := f.tasks[idx]
-		if expiry := task.GetExpireTime(); expiry.IsValid() && f.now().After(expiry.AsTime()) {
+		if expire := task.GetExpireTime(); expire.IsValid() && f.now().After(expire.AsTime()) {
 			continue
 		}
 		if task.GetDeleteTime().IsValid() && !req.GetShowDeleted() {
@@ -582,7 +582,7 @@ func (f *Fake) ListProjects(ctx context.Context, req *pb.ListProjectsRequest) (*
 	res := &pb.ListProjectsResponse{}
 	for idx := minIndex; idx < len(f.projects) && len(res.GetProjects()) <= int(pageSize); idx++ {
 		project := f.projects[idx]
-		if expiry := project.GetExpireTime(); expiry.IsValid() && f.now().After(expiry.AsTime()) {
+		if expire := project.GetExpireTime(); expire.IsValid() && f.now().After(expire.AsTime()) {
 			continue
 		}
 		if project.GetDeleteTime().IsValid() && !req.GetShowDeleted() {

--- a/tasks/testsuite/projects.go
+++ b/tasks/testsuite/projects.go
@@ -1093,8 +1093,8 @@ func (s *Suite) TestDeleteProject() {
 		if err := deleted.GetExpireTime().CheckValid(); err != nil {
 			t.Errorf("first deletion: expire_time is invalid: %v", err)
 		}
-		if delete, expiry := deleted.GetDeleteTime().AsTime(), deleted.GetExpireTime().AsTime(); expiry.Before(delete) {
-			t.Errorf("first deletion: delete_time = %v; wanted before expire_time = %v", delete, expiry)
+		if delete, expire := deleted.GetDeleteTime().AsTime(), deleted.GetExpireTime().AsTime(); expire.Before(delete) {
+			t.Errorf("first deletion: delete_time = %v; wanted before expire_time = %v", delete, expire)
 		}
 	}
 

--- a/tasks/testsuite/tasks.go
+++ b/tasks/testsuite/tasks.go
@@ -1262,10 +1262,10 @@ func (s *Suite) TestDeleteTask() {
 			t.Errorf("first deletion: delete_time is invalid: %v", err)
 		}
 		if err := deleted.GetExpireTime().CheckValid(); err != nil {
-			t.Errorf("first deletion: expiry_time is invalid: %v", err)
+			t.Errorf("first deletion: expire_time is invalid: %v", err)
 		}
-		if delete, expiry := deleted.GetDeleteTime().AsTime(), deleted.GetExpireTime().AsTime(); expiry.Before(delete) {
-			t.Errorf("first deletion: delete_time = %v; wanted before expiry_time = %v", delete, expiry)
+		if delete, expire := deleted.GetDeleteTime().AsTime(), deleted.GetExpireTime().AsTime(); expire.Before(delete) {
+			t.Errorf("first deletion: delete_time = %v; wanted before expire_time = %v", delete, expire)
 		}
 	}
 


### PR DESCRIPTION
This was a typo from previous that I thought I had cleaned up, but apparently not.