### PR TITLE
tasks: use `grpctest` package instead of homegrown setup.

### DIFF
--- a/tasks/fake/BUILD.bazel
+++ b/tasks/fake/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     srcs = ["fake_test.go"],
     embed = [":fake"],
     deps = [
+        "//grpctest",
         "//tasks/tasks_go_proto",
         "//tasks/testsuite",
         "@com_github_jonboulle_clockwork//:clockwork",

--- a/tasks/fake/fake_test.go
+++ b/tasks/fake/fake_test.go
@@ -2,64 +2,14 @@ package fake
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/suite"
+	"go.saser.se/grpctest"
 	pb "go.saser.se/tasks/tasks_go_proto"
 	"go.saser.se/tasks/testsuite"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
-
-// setup sets up a gRPC server listening to an in-process buffer and serves the
-// given Fake on it.
-func setup(ctx context.Context, t *testing.T, svc *Fake) pb.TasksClient {
-	t.Helper()
-
-	const bufSize = 1024 * 1024
-	lis := bufconn.Listen(bufSize)
-	t.Cleanup(func() {
-		if err := lis.Close(); err != nil {
-			t.Error(err)
-		}
-	})
-
-	srv := grpc.NewServer()
-	pb.RegisterTasksServer(srv, svc)
-	errc := make(chan error, 1)
-	go func() {
-		errc <- srv.Serve(lis)
-	}()
-	t.Cleanup(func() {
-		srv.GracefulStop()
-		if err := <-errc; err != nil {
-			t.Error(err)
-		}
-	})
-
-	dialer := func(context.Context, string) (net.Conn, error) {
-		return lis.Dial()
-	}
-	cc, err := grpc.DialContext(
-		ctx,
-		"bufconn",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialer),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := cc.Close(); err != nil {
-			t.Error(err)
-		}
-	})
-
-	return pb.NewTasksClient(cc)
-}
 
 // truncater implements testsuite.Truncater to clean out state between tests or
 // whenever needed.
@@ -98,7 +48,11 @@ func TestService(t *testing.T) {
 	svc := New()
 	clock := clockwork.NewFakeClock()
 	svc.clock = clock
-	client := setup(ctx, t, svc)
+	srv := grpctest.New(ctx, t, grpctest.Options{
+		ServiceDesc:    &pb.Tasks_ServiceDesc,
+		Implementation: svc,
+	})
+	client := pb.NewTasksClient(srv.ClientConn)
 	s := testsuite.New(client, &truncater{s: svc}, clock, maxPageSize)
 	suite.Run(t, s)
 }

--- a/tasks/service/BUILD.bazel
+++ b/tasks/service/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     data = ["//tasks/postgres:schema.sql"],
     embed = [":service"],
     deps = [
+        "//grpctest",
         "//postgres",
         "//postgres/postgrestest",
         "//tasks/tasks_go_proto",

--- a/tasks/service/service_test.go
+++ b/tasks/service/service_test.go
@@ -2,66 +2,16 @@ package service
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/suite"
+	"go.saser.se/grpctest"
 	"go.saser.se/postgres"
 	"go.saser.se/postgres/postgrestest"
 	pb "go.saser.se/tasks/tasks_go_proto"
 	"go.saser.se/tasks/testsuite"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
-
-func setup(ctx context.Context, t *testing.T, pool *postgres.Pool, clock clockwork.FakeClock) pb.TasksClient {
-	t.Helper()
-
-	const bufSize = 1024 * 1024
-	lis := bufconn.Listen(bufSize)
-	t.Cleanup(func() {
-		if err := lis.Close(); err != nil {
-			t.Error(err)
-		}
-	})
-
-	srv := grpc.NewServer()
-	svc := New(pool)
-	svc.clock = clock
-	pb.RegisterTasksServer(srv, svc)
-	errc := make(chan error, 1)
-	go func() {
-		errc <- srv.Serve(lis)
-	}()
-	t.Cleanup(func() {
-		srv.GracefulStop()
-		if err := <-errc; err != nil {
-			t.Error(err)
-		}
-	})
-
-	dialer := func(context.Context, string) (net.Conn, error) {
-		return lis.Dial()
-	}
-	cc, err := grpc.DialContext(
-		ctx,
-		"bufconn",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialer),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := cc.Close(); err != nil {
-			t.Error(err)
-		}
-	})
-
-	return pb.NewTasksClient(cc)
-}
 
 type poolTruncater struct {
 	pool *postgres.Pool
@@ -75,8 +25,14 @@ func (pt *poolTruncater) Truncate(ctx context.Context) error {
 func TestService(t *testing.T) {
 	ctx := context.Background()
 	pool := postgrestest.Open(ctx, t, "tasks/postgres/schema.sql")
+	svc := New(pool)
 	clock := clockwork.NewFakeClock()
-	client := setup(ctx, t, pool, clock)
+	svc.clock = clock
+	srv := grpctest.New(ctx, t, grpctest.Options{
+		ServiceDesc:    &pb.Tasks_ServiceDesc,
+		Implementation: svc,
+	})
+	client := pb.NewTasksClient(srv.ClientConn)
 	s := testsuite.New(client, &poolTruncater{pool: pool}, clock, maxPageSize)
 	suite.Run(t, s)
 }


### PR DESCRIPTION
The previous setups pulled their weight but now there is a central implementation of the same functionality.