### PR TITLE
tasks: implement `CreateLabel`.

### DIFF
--- a/tasks/postgres/schema.sql
+++ b/tasks/postgres/schema.sql
@@ -42,6 +42,20 @@ CREATE TABLE projects (
     CONSTRAINT delete_time_not_after_expire_time CHECK (delete_time IS NULL OR delete_time <= expire_time)
 );
 
+-- The main table of labels.
+CREATE TABLE labels (
+    id BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
+    label TEXT NOT NULL,
+    create_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    update_time TIMESTAMP WITH TIME ZONE, -- If non-null, then project has been updated at least once.
+
+    PRIMARY KEY (id),
+    CONSTRAINT label_not_empty CHECK (label <> ''),
+    CONSTRAINT label_is_unique UNIQUE (label),
+    CONSTRAINT label_contains_valid_characters CHECK (label ~* '^[a-zA-Z0-9\-\_\:\@]+$'),
+    CONSTRAINT create_time_not_after_update_time CHECK (update_time IS NULL OR create_time <= update_time)
+);
+
 -- A table of page tokens. The rows in this table define the set of acceptable
 -- values for ListTasksRequest.next_page_token.
 CREATE TABLE task_page_tokens (

--- a/tasks/testsuite/labels.go
+++ b/tasks/testsuite/labels.go
@@ -491,7 +491,6 @@ func (s *Suite) TestListLabels_Error() {
 func (s *Suite) TestCreateLabel() {
 	t := s.T()
 	ctx := context.Background()
-	t.Skip("not implemented")
 
 	for _, req := range []*pb.CreateLabelRequest{
 		{Label: &pb.Label{Label: "email"}},
@@ -526,7 +525,6 @@ func (s *Suite) TestCreateLabel() {
 func (s *Suite) TestCreateLabel_Duplicate() {
 	t := s.T()
 	ctx := context.Background()
-	t.Skip("not implemented")
 
 	// We create the original label, which should succeed.
 	original := s.client.CreateLabelT(ctx, t, &pb.CreateLabelRequest{
@@ -554,7 +552,6 @@ func (s *Suite) TestCreateLabel_Duplicate() {
 func (s *Suite) TestCreateLabel_Error() {
 	t := s.T()
 	ctx := context.Background()
-	t.Skip("not implemented")
 
 	for _, tt := range []struct {
 		name string


### PR DESCRIPTION
This was a little bit more interesting compared to tasks and projects, as there are two constraints that must be enforced:
    * Label strings must only contain valid characters.
    * Label strings must be unique.