### PR TITLE
tasks/fake: add truncation of label-related data.

### DIFF
--- a/tasks/fake/fake_test.go
+++ b/tasks/fake/fake_test.go
@@ -40,6 +40,15 @@ func (t *truncater) Truncate(ctx context.Context) error {
 		delete(t.s.projectIndices, k)
 	}
 	t.s.nextProjectID = 1
+
+	t.s.labels = []*pb.Label{}
+	for k := range t.s.labelPageTokens {
+		delete(t.s.labelPageTokens, k)
+	}
+	for k := range t.s.labelIndices {
+		delete(t.s.labelIndices, k)
+	}
+	t.s.nextLabelID = 1
 	return nil
 }
 


### PR DESCRIPTION
This was supposed to be done in commit f1d0064ce0bad3c4e4d74cc558a0ac7d0a27e5a6 but I forgot it and it wasn't caught by tests.