### PR TITLE
WORKSPACE: bump Go version 1.19.1 -> 1.19.2.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,7 @@ go_repositories()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.19.1")
+go_register_toolchains(version = "1.19.2")
 
 gazelle_dependencies()
 


### PR DESCRIPTION
No interesting changes from what I can see, but it's good to stay up to date.