### PR TITLE
tools.mk: bump Go version.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,7 @@ go_repositories()
 
 go_rules_dependencies()
 
+# This version number must be kept in sync with tools.mk.
 go_register_toolchains(version = "1.19.2")
 
 gazelle_dependencies()

--- a/tools.mk
+++ b/tools.mk
@@ -14,7 +14,7 @@ $(tools):
 # specified in the WORKSPACE file.
 #
 # The version must be kept in sync with the WORKSPACE file.
-go_version := 1.19.1
+go_version := 1.19.2
 go_archive := $(tools)/go_$(go_version).tar.gz
 $(go_archive): | $(tools)
 	curl \


### PR DESCRIPTION
I forgot to do this when updating WORKSPACE in commit 01d9d2445ce3c96def4be2a7c0c2549e3e9bb0fe.

There is a comment pointing tools.mk -> WORKSPACE, and this commit adds a comment WORKSPACE -> tools.mk. I don't have the energy to invest into some automated check for this right now.