### PR TITLE
runfiles/cc: add C++ convenience library for reading runfiles.

### DIFF
--- a/runfiles/BUILD.bazel
+++ b/runfiles/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+exports_files(
+    ["test.txt"],
+    visibility = ["//runfiles:__subpackages__"],
+)
+
 go_library(
     name = "runfiles",
     srcs = ["runfiles.go"],

--- a/runfiles/cc/BUILD.bazel
+++ b/runfiles/cc/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "runfiles",
+    srcs = ["runfiles.cc"],
+    hdrs = ["runfiles.h"],
+    deps = [
+        "@bazel_tools//tools/cpp/runfiles",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "runfiles_test",
+    srcs = ["runfiles_test.cc"],
+    data = ["//runfiles:test.txt"],
+    deps = [
+        ":runfiles",
+        "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/runfiles/cc/runfiles.cc
+++ b/runfiles/cc/runfiles.cc
@@ -1,0 +1,97 @@
+#include "runfiles/cc/runfiles.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+namespace runfiles {
+namespace cc {
+namespace runfiles {
+namespace {
+absl::StatusOr<std::string> runfilePath(
+    absl::string_view runfile,
+    bazel::tools::cpp::runfiles::Runfiles* runfiles) {
+  const auto path = runfiles->Rlocation(std::string(runfile));
+  if (path == "") {
+    return absl::NotFoundError("runfiles: couldn't find runfile " +
+                               std::string(runfile));
+  }
+  // runfiles->Rlocation may return a path even for a file that doesn't exist,
+  // for some reason. The documentation states that the caller should check for
+  // the existence of the file.
+  if (!std::filesystem::exists(path)) {
+    return absl::NotFoundError("runfiles: couldn't find runfile " +
+                               std::string(runfile) + " (path: " + path + ")");
+  }
+  return path;
+}
+
+absl::StatusOr<std::string> readRunfile(
+    absl::string_view runfile,
+    bazel::tools::cpp::runfiles::Runfiles* runfiles) {
+  const auto path = runfilePath(runfile, runfiles);
+  if (!path.ok()) {
+    return path;
+  }
+  std::ifstream f(*path);
+  std::stringstream buf;
+  buf << f.rdbuf();
+  if (f.fail()) {
+    return absl::UnknownError("runfiles: couldn't read runfile " +
+                              std::string(runfile));
+  }
+  return buf.str();
+}
+}  // namespace
+
+absl::StatusOr<std::string> Path(absl::string_view runfile,
+                                 absl::string_view argv0) {
+  std::string error;
+  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles(
+      bazel::tools::cpp::runfiles::Runfiles::Create(std::string(argv0),
+                                                    &error));
+  if (runfiles == nullptr) {
+    return absl::UnknownError("runfiles: " + error);
+  }
+  return runfilePath(runfile, runfiles.get());
+}
+
+absl::StatusOr<std::string> Read(absl::string_view runfile,
+                                 absl::string_view argv0) {
+  std::string error;
+  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles(
+      bazel::tools::cpp::runfiles::Runfiles::Create(std::string(argv0),
+                                                    &error));
+  if (runfiles == nullptr) {
+    return absl::UnknownError("runfiles: " + error);
+  }
+  return readRunfile(runfile, runfiles.get());
+}
+
+absl::StatusOr<std::string> PathForTest(absl::string_view runfile) {
+  std::string error;
+  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles(
+      bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&error));
+  if (runfiles == nullptr) {
+    return absl::InternalError("runfiles: " + error);
+  }
+  return runfilePath(runfile, runfiles.get());
+}
+
+absl::StatusOr<std::string> ReadForTest(absl::string_view runfile) {
+  std::string error;
+  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles(
+      bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&error));
+  if (runfiles == nullptr) {
+    return absl::UnknownError("runfiles: " + error);
+  }
+  return readRunfile(runfile, runfiles.get());
+}
+}  // namespace runfiles
+}  // namespace cc
+}  // namespace runfiles

--- a/runfiles/cc/runfiles.h
+++ b/runfiles/cc/runfiles.h
@@ -1,0 +1,47 @@
+#ifndef RUNFILES_CC_RUNFILES_H_
+#define RUNFILES_CC_RUNFILES_H_
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace runfiles {
+namespace cc {
+namespace runfiles {
+// Path returns the absolute path for the given runfiles, if it exists. If it
+// doesn't exist, the status contains an error. The runfile argument _must_
+// contain the name of the repository of the runfile, even if it is in the local
+// repository.
+//
+// Use this in `cc_library` and  `cc_binary` targets, and use PathForTest in
+// `cc_test` targets.
+absl::StatusOr<std::string> Path(absl::string_view runfile,
+                                 absl::string_view argv0 = "");
+
+// Read is like Path, but returns the contents of the file rather than the
+// absolute path to it.
+//
+// Use this in `cc_library` and  `cc_binary` targets, and use ReadForTest in
+// `cc_test` targets.
+absl::StatusOr<std::string> Read(absl::string_view runfile,
+                                 absl::string_view argv0 = "");
+
+// PathForTest returns the absolute path for the given runfile, if it exists. If
+// it doesn't exist, the status contains an error. The runfile argument _must_
+// contain the name of the repository of the runfile, even if it is in the local
+// repository.
+//
+// Use this in `cc_test` targets, and use Path in `cc_library` and `cc_binary`
+// targets.
+absl::StatusOr<std::string> PathForTest(absl::string_view runfile);
+
+// ReadForTest is like PathForTest, but returns the contents of the file rather
+// than the path to it.
+//
+// Use this in `cc_test` targets, and use Path in `cc_library` and `cc_binary`
+// targets.
+absl::StatusOr<std::string> ReadForTest(absl::string_view runfile);
+}  // namespace runfiles
+}  // namespace cc
+}  // namespace runfiles
+
+#endif

--- a/runfiles/cc/runfiles_test.cc
+++ b/runfiles/cc/runfiles_test.cc
@@ -1,0 +1,31 @@
+#include "runfiles/cc/runfiles.h"
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+
+TEST(Runfiles, PathForTest) {
+  const auto got =
+      runfiles::cc::runfiles::PathForTest("code/runfiles/test.txt");
+  ASSERT_TRUE(got.ok()) << "Unexpected error: " << got.status();
+  EXPECT_NE(*got, "");
+}
+
+TEST(Runfiles, ReadForTest) {
+  const auto got =
+      runfiles::cc::runfiles::ReadForTest("code/runfiles/test.txt");
+  const auto want = "This is an example file to be used in tests.\n";
+  ASSERT_TRUE(got.ok()) << "Unexpected error: " << got.status();
+  EXPECT_EQ(*got, want);
+}
+
+TEST(Runfiles, PathForTestNotFound) {
+  const auto got =
+      runfiles::cc::runfiles::PathForTest("code/runfiles/does_not_exist.txt");
+  ASSERT_EQ(got.status().code(), absl::StatusCode::kNotFound);
+}
+
+TEST(Runfiles, ReadForTestNotFound) {
+  const auto got =
+      runfiles::cc::runfiles::ReadForTest("code/runfiles/does_not_exist.txt");
+  ASSERT_EQ(got.status().code(), absl::StatusCode::kNotFound);
+}


### PR DESCRIPTION
Not as pleasant to write this code as for Go -- being unable to detect various error conditions for opening the file is probably the biggest hurdle -- but this makes it tolerable to work with at least.