### PR TITLE
adventofcode/cc: add small utility function to trim strings.

### DIFF
--- a/adventofcode/cc/BUILD.bazel
+++ b/adventofcode/cc/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "trim",
+    srcs = ["trim.cc"],
+    hdrs = ["trim.h"],
+    deps = ["@com_google_absl//absl/strings"],
+)
+
+cc_test(
+    name = "trim_test",
+    srcs = ["trim_test.cc"],
+    deps = [
+        ":trim",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/adventofcode/cc/trim.cc
+++ b/adventofcode/cc/trim.cc
@@ -1,0 +1,22 @@
+#include "adventofcode/cc/trim.h"
+
+#include "absl/strings/string_view.h"
+
+namespace adventofcode {
+namespace cc {
+namespace trim {
+absl::string_view TrimSpace(absl::string_view s) {
+  static constexpr absl::string_view whitespace = " \n";
+  auto start = s.find_first_not_of(whitespace);
+  if (start == absl::string_view::npos) {
+    start = 0;
+  }
+  auto end = s.find_last_not_of(whitespace);
+  if (end == absl::string_view::npos) {
+    end = s.length();
+  }
+  return s.substr(start, end - start + 1);
+}
+}  // namespace trim
+}  // namespace cc
+}  // namespace adventofcode

--- a/adventofcode/cc/trim.h
+++ b/adventofcode/cc/trim.h
@@ -1,0 +1,16 @@
+#ifndef ADVENTOFCODE_CC_TRIM_H_
+#define ADVENTOFCODE_CC_TRIM_H_
+
+#include "absl/strings/string_view.h"
+
+namespace adventofcode {
+namespace cc {
+namespace trim {
+// TrimSpace removes leading and trailing space characters (' ') and newline
+// characters ('\n') and returns a new absl::string_view backed by the same data
+// as s.
+absl::string_view TrimSpace(absl::string_view s);
+}  // namespace trim
+}  // namespace cc
+}  // namespace adventofcode
+#endif

--- a/adventofcode/cc/trim_test.cc
+++ b/adventofcode/cc/trim_test.cc
@@ -1,0 +1,17 @@
+#include "adventofcode/cc/trim.h"
+
+#include <unordered_map>
+
+#include "gtest/gtest.h"
+
+TEST(TrimTest, TrimSpace) {
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace(""), "");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace("hello"), "hello");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace(" hello"), "hello");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace("hello "), "hello");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace(" hello "), "hello");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace("hello\n"), "hello");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace("\nhello\n"), "hello");
+  EXPECT_EQ(adventofcode::cc::trim::TrimSpace("   \nhello  \n   \n   \n"),
+            "hello");
+}


### PR DESCRIPTION
This will be useful when writing tests that read inputs and outputs from files, which are generally terminated by a newline.