### PR TITLE
adventofcode/cc/year2022: reformat `BUILD.bazel`.

### DIFF
--- a/adventofcode/cc/year2022/BUILD.bazel
+++ b/adventofcode/cc/year2022/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//adventofcode/cc/tools:build_defs.bzl", "cc_aoc_benchmark", "cc_aoc_test")
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//adventofcode/cc/tools:build_defs.bzl", "cc_aoc_benchmark", "cc_aoc_test")
 
 cc_library(
     name = "day01",


### PR DESCRIPTION
Managed to mess this up in one of the previous commits; a simple `make fix` sorted that out!