### PR TITLE
adventofcode/cc/tools/generate_benchmark: fix package documentation.

### DIFF
--- a/adventofcode/cc/tools/generate_benchmark/main.go
+++ b/adventofcode/cc/tools/generate_benchmark/main.go
@@ -1,5 +1,5 @@
-// Command generate_test generates a C++ source file implementing a unit test
-// for Advent of Code solutions.
+// Command generate_benchmark generates a C++ source file implementing a
+// microbenchmark for Advent of Code solutions.
 package main
 
 import (


### PR DESCRIPTION
I apparently forgot to update this when I copy-pasted over from the `generate_test` tool, oops.