### PR TITLE
adventofcode/cc/tools/generate_benchmark: correctly exit on errors.

### DIFF
--- a/adventofcode/cc/tools/generate_benchmark/dayXX_benchmark.cc.template
+++ b/adventofcode/cc/tools/generate_benchmark/dayXX_benchmark.cc.template
@@ -11,9 +11,11 @@ static void BM_Part1(benchmark::State& state, absl::string_view input, absl::str
   absl::StatusOr<std::string> got = {{.Namespace}}::{{.Part1Func}}(input);
   if (!got.ok()) {
     state.SkipWithError(got.status().ToString().c_str());
+    return;
   }
   if (*got != want) {
     state.SkipWithError(absl::StrFormat("got \"%s\"; want \"%s\"", *got, want).c_str());
+    return;
   }
   for (auto _ : state) {
     benchmark::DoNotOptimize({{.Namespace}}::{{.Part1Func}}(input));
@@ -27,9 +29,11 @@ static void BM_Part2(benchmark::State& state, absl::string_view input, absl::str
   absl::StatusOr<std::string> got = {{.Namespace}}::{{.Part2Func}}(input);
   if (!got.ok()) {
     state.SkipWithError(got.status().ToString().c_str());
+    return;
   }
   if (*got != want) {
     state.SkipWithError(absl::StrFormat("got \"%s\"; want \"%s\"", *got, want).c_str());
+    return;
   }
   for (auto _ : state) {
     benchmark::DoNotOptimize({{.Namespace}}::{{.Part2Func}}(input));


### PR DESCRIPTION
I am so used to Go and thought thate `state.SkipWithError` behaved like `b.Fatal`, i.e., correctly aborting the benchmark. It does not, but a simple `return` statement fixes that.