### PR TITLE
adventofcode/cc/tools/generate_test: make test output less noisy.

### DIFF
--- a/adventofcode/cc/tools/build_defs.bzl
+++ b/adventofcode/cc/tools/build_defs.bzl
@@ -143,7 +143,11 @@ def cc_aoc_test(
 
     part1_pairs = []
     for in_file, out_file in part1.items():
-        part1_pairs.append("$(location %s):$(location %s)" % (in_file, out_file))
+        in_parts = in_file.split(":")[-1].split(".")
+        if len(in_parts) != 3:
+            fail('part1: input file "%s" does not have format "dayXX.<name>.in"' % in_file)
+        pair_name = in_parts[1]
+        part1_pairs.append("%s:$(location %s):$(location %s)" % (pair_name, in_file, out_file))
         if in_file not in srcs:
             srcs.append(in_file)
         if out_file not in srcs:
@@ -153,7 +157,11 @@ def cc_aoc_test(
 
     part2_pairs = []
     for in_file, out_file in part2.items():
-        part2_pairs.append("$(location %s):$(location %s)" % (in_file, out_file))
+        in_parts = in_file.split(":")[-1].split(".")
+        if len(in_parts) != 3:
+            fail('part2: input file "%s" does not have format "dayXX.<name>.in"' % in_file)
+        pair_name = in_parts[1]
+        part2_pairs.append("%s:$(location %s):$(location %s)" % (pair_name, in_file, out_file))
         if in_file not in srcs:
             srcs.append(in_file)
         if out_file not in srcs:

--- a/adventofcode/cc/tools/generate_test/dayXX_test.cc.template
+++ b/adventofcode/cc/tools/generate_test/dayXX_test.cc.template
@@ -1,50 +1,29 @@
-#include "{{.HeaderFile}}"
+{{ with $top := . -}}
+#include "{{$top.HeaderFile}}"
 
-#include <utility>
+#include <string>
 
+#include "absl/status/statusor.h"
 #include "adventofcode/cc/trim.h"
 #include "gtest/gtest.h"
 
-class Part1Test
-    : public testing::TestWithParam<std::pair<const char *, const char *>> {};
-
-TEST_P(Part1Test, Solve) {
-  const auto in_out = GetParam();
-  const auto input = in_out.first;
-  const auto want = in_out.second;
-  const auto got = {{.Namespace}}::{{.Part1Func}}(input);
+{{ range $pair := $top.Part1Pairs }}
+TEST(Part1Test, {{$pair.Name}}) {
+  const std::string& input = R"({{$pair.In}})";
+  const std::string& want = R"({{$pair.Out}})";
+  const absl::StatusOr<std::string> got = {{$top.Namespace}}::{{$top.Part1Func}}(input);
   ASSERT_TRUE(got.ok()) << "Solve: " << got.status();
   EXPECT_EQ(*got, adventofcode::cc::trim::TrimSpace(want));
 }
+{{ end }}
 
-INSTANTIATE_TEST_SUITE_P(
-    Instances, Part1Test,
-    testing::Values(
-        {{- range $i, $pair := .Part1Pairs }}
-        {{ if $i }},
-        {{ end -}}
-        std::pair(R"({{.In}})",
-                  R"({{.Out}})")
-        {{ end -}}));
-
-class Part2Test
-    : public testing::TestWithParam<std::pair<const char *, const char *>> {};
-
-TEST_P(Part2Test, Solve) {
-  const auto in_out = GetParam();
-  const auto input = in_out.first;
-  const auto want = in_out.second;
-  const auto got = {{.Namespace}}::{{.Part2Func}}(input);
+{{ range $pair := $top.Part2Pairs }}
+TEST(Part2Test, {{$pair.Name}}) {
+  const std::string& input = R"({{$pair.In}})";
+  const std::string& want = R"({{$pair.Out}})";
+  const absl::StatusOr<std::string> got = {{$top.Namespace}}::{{$top.Part2Func}}(input);
   ASSERT_TRUE(got.ok()) << "Solve: " << got.status();
   EXPECT_EQ(*got, adventofcode::cc::trim::TrimSpace(want));
 }
-
-INSTANTIATE_TEST_SUITE_P(
-    Instances, Part2Test,
-    testing::Values(
-        {{- range $i, $pair := .Part2Pairs }}
-        {{ if $i }},
-        {{ end -}}
-        std::pair(R"({{.In}})",
-                  R"({{.Out}})")
-        {{ end -}}));
+{{ end }}
+{{- end }}

--- a/adventofcode/cc/tools/generate_test/main.go
+++ b/adventofcode/cc/tools/generate_test/main.go
@@ -26,8 +26,8 @@ var (
 	namespaceFlag = flag.String("namespace", "", `The namespace in which the solver functions live. Should be double-colon-separated, e.g., "adventofcode::cc::year2022::day01". If left empty the value will be derived from the -header_file flag by replacing slashes with double colons and stripping the .h suffix, e.g., "adventofcode/cc/year2022/day01.h" => "adventofcode::cc::year2022::day01".`)
 	part1Func     = flag.String("part1_func", "Part1", "The name of the function solving part 1.")
 	part2Func     = flag.String("part2_func", "Part2", "The name of the function solving part 2.")
-	part1Pairs    = flag.String("part1_pairs", "", `Comma-separated list of file pairs of the form "in_file:out_file" containing problem inputs and corresponding expected outputs.`)
-	part2Pairs    = flag.String("part2_pairs", "", `Comma-separated list of file pairs of the form "in_file:out_file" containing problem inputs and corresponding expected outputs.`)
+	part1Pairs    = flag.String("part1_pairs", "", `Comma-separated list of file pairs of the form "name:in_file:out_file" containing problem inputs and corresponding expected outputs.`)
+	part2Pairs    = flag.String("part2_pairs", "", `Comma-separated list of file pairs of the form "name:in_file:out_file" containing problem inputs and corresponding expected outputs.`)
 
 	output = flag.String("output", "", "Path to write the generated file to. Leaving this empty writes the file to stdout.")
 )
@@ -39,6 +39,7 @@ var (
 )
 
 type inOutPair struct {
+	Name    string
 	In, Out string
 }
 
@@ -77,10 +78,12 @@ func errmain() error {
 		return errors.New("-part1_pairs is required but was empty")
 	}
 	for _, pair := range strings.Split(*part1Pairs, ",") {
-		in, out, ok := strings.Cut(pair, ":")
-		if !ok {
+		parts := strings.Split(pair, ":")
+		if len(parts) != 3 {
 			return fmt.Errorf("-part1_pairs contains invalid element %q", pair)
 		}
+		name := parts[0]
+		in, out := parts[1], parts[2]
 		inData, err := os.ReadFile(in)
 		if err != nil {
 			return fmt.Errorf("-part1_pairs contained unreadable file: %v", err)
@@ -90,8 +93,9 @@ func errmain() error {
 			return fmt.Errorf("-part1_pairs contained unreadable file: %v", err)
 		}
 		args.Part1Pairs = append(args.Part1Pairs, inOutPair{
-			In:  string(inData),
-			Out: string(outData),
+			Name: name,
+			In:   string(inData),
+			Out:  string(outData),
 		})
 	}
 
@@ -99,10 +103,12 @@ func errmain() error {
 		return errors.New("-part2_pairs is required but was empty")
 	}
 	for _, pair := range strings.Split(*part2Pairs, ",") {
-		in, out, ok := strings.Cut(pair, ":")
-		if !ok {
+		parts := strings.Split(pair, ":")
+		if len(parts) != 3 {
 			return fmt.Errorf("-part2_pairs contains invalid element %q", pair)
 		}
+		name := parts[0]
+		in, out := parts[1], parts[2]
 		inData, err := os.ReadFile(in)
 		if err != nil {
 			return fmt.Errorf("-part2_pairs contained unreadable file: %v", err)
@@ -112,8 +118,9 @@ func errmain() error {
 			return fmt.Errorf("-part2_pairs contained unreadable file: %v", err)
 		}
 		args.Part2Pairs = append(args.Part2Pairs, inOutPair{
-			In:  string(inData),
-			Out: string(outData),
+			Name: name,
+			In:   string(inData),
+			Out:  string(outData),
 		})
 	}
 


### PR DESCRIPTION
With the parameterized tests, the full test input would be printed on test failure. This made for very noisy output that was a pain to scroll through. I solved this by introducing a test "name" that is used instead.