### PR TITLE
adventofcode/cc/tools: relax requirements on input flags.

### DIFF
--- a/adventofcode/cc/tools/build_defs.bzl
+++ b/adventofcode/cc/tools/build_defs.bzl
@@ -98,7 +98,9 @@ def cc_aoc_test(
             will be derived from `header_file`: if `header_file` is
             "path/to/day01.h", `namespace` will be "path::to::day01".
         part1_func: string. The function within `namespace` solving part 1.
+            Required if `part1` is non-empty.
         part2_func: string. The function within `namespace` solving part 2.
+            Required if `part2` is non-empty.
         part1: map[label]label. Keys are files containing inputs, values are
             files containing corresponding expected outputs. Must not be empty.
         part2: map[label]label. Keys are files containing inputs, values are
@@ -123,12 +125,6 @@ def cc_aoc_test(
         # Transform header_file = "path/to/target.h" into "path::to::target".
         namespace = "::".join(header_file.removesuffix(".h").split("/"))
 
-    if not part1:
-        fail("part1_pairs must not be empty")
-
-    if not part2:
-        fail("part2_pairs must not be empty")
-
     output = name + ".cc"
     srcs = []
     outs = [output]
@@ -136,38 +132,44 @@ def cc_aoc_test(
         "$(location //adventofcode/cc/tools/generate_test)",
         "--header_file='%s'" % header_file,
         "--namespace='%s'" % namespace,
-        "--part1_func='%s'" % part1_func,
-        "--part2_func='%s'" % part2_func,
         "--output='$(location %s)'" % output,
     ]
 
-    part1_pairs = []
-    for in_file, out_file in part1.items():
-        in_parts = in_file.split(":")[-1].split(".")
-        if len(in_parts) != 3:
-            fail('part1: input file "%s" does not have format "dayXX.<name>.in"' % in_file)
-        pair_name = in_parts[1]
-        part1_pairs.append("%s:$(location %s):$(location %s)" % (pair_name, in_file, out_file))
-        if in_file not in srcs:
-            srcs.append(in_file)
-        if out_file not in srcs:
-            srcs.append(out_file)
-    part1_pairs_arg = ",".join(part1_pairs)
-    cmd.append("--part1_pairs='%s'" % part1_pairs_arg)
+    if part1:
+        if not part1_func:
+            fail("part1_func is empty, but it is required because part1 is non-empty")
+        cmd.append("--part1_func='%s'" % part1_func)
+        part1_pairs = []
+        for in_file, out_file in part1.items():
+            in_parts = in_file.split(":")[-1].split(".")
+            if len(in_parts) != 3:
+                fail('part1: input file "%s" does not have format "dayXX.<name>.in"' % in_file)
+            pair_name = in_parts[1]
+            part1_pairs.append("%s:$(location %s):$(location %s)" % (pair_name, in_file, out_file))
+            if in_file not in srcs:
+                srcs.append(in_file)
+            if out_file not in srcs:
+                srcs.append(out_file)
+        part1_pairs_arg = ",".join(part1_pairs)
+        cmd.append("--part1_pairs='%s'" % part1_pairs_arg)
 
-    part2_pairs = []
-    for in_file, out_file in part2.items():
-        in_parts = in_file.split(":")[-1].split(".")
-        if len(in_parts) != 3:
-            fail('part2: input file "%s" does not have format "dayXX.<name>.in"' % in_file)
-        pair_name = in_parts[1]
-        part2_pairs.append("%s:$(location %s):$(location %s)" % (pair_name, in_file, out_file))
-        if in_file not in srcs:
-            srcs.append(in_file)
-        if out_file not in srcs:
-            srcs.append(out_file)
-    part2_pairs_arg = ",".join(part2_pairs)
-    cmd.append("--part2_pairs='%s'" % part2_pairs_arg)
+    if part2:
+        if not part2_func:
+            fail("part2_func is empty, but it is required because part2 is non-empty")
+        cmd.append("--part2_func='%s'" % part2_func)
+        part2_pairs = []
+        for in_file, out_file in part2.items():
+            in_parts = in_file.split(":")[-1].split(".")
+            if len(in_parts) != 3:
+                fail('part2: input file "%s" does not have format "dayXX.<name>.in"' % in_file)
+            pair_name = in_parts[1]
+            part2_pairs.append("%s:$(location %s):$(location %s)" % (pair_name, in_file, out_file))
+            if in_file not in srcs:
+                srcs.append(in_file)
+            if out_file not in srcs:
+                srcs.append(out_file)
+        part2_pairs_arg = ",".join(part2_pairs)
+        cmd.append("--part2_pairs='%s'" % part2_pairs_arg)
 
     native.genrule(
         name = name + "_cc",
@@ -208,7 +210,9 @@ def cc_aoc_benchmark(
             will be derived from `header_file`: if `header_file` is
             "path/to/day01.h", `namespace` will be "path::to::day01".
         part1_func: string. The function within `namespace` solving part 1.
+            Required if `part1` is non-empty.
         part2_func: string. The function within `namespace` solving part 2.
+            Required if `part2` is non-empty.
         part1: map[label]label. Keys are files containing inputs, values are
             files containing corresponding expected outputs. Must not be empty.
         part2: map[label]label. Keys are files containing inputs, values are
@@ -233,12 +237,6 @@ def cc_aoc_benchmark(
         # Transform header_file = "path/to/target.h" into "path::to::target".
         namespace = "::".join(header_file.removesuffix(".h").split("/"))
 
-    if not part1:
-        fail("part1_pairs must not be empty")
-
-    if not part2:
-        fail("part2_pairs must not be empty")
-
     output = name + ".cc"
     srcs = []
     outs = [output]
@@ -246,30 +244,36 @@ def cc_aoc_benchmark(
         "$(location //adventofcode/cc/tools/generate_benchmark)",
         "--header_file='%s'" % header_file,
         "--namespace='%s'" % namespace,
-        "--part1_func='%s'" % part1_func,
-        "--part2_func='%s'" % part2_func,
         "--output='$(location %s)'" % output,
     ]
 
-    part1_pairs = []
-    for in_file, out_file in part1.items():
-        part1_pairs.append("$(location %s):$(location %s)" % (in_file, out_file))
-        if in_file not in srcs:
-            srcs.append(in_file)
-        if out_file not in srcs:
-            srcs.append(out_file)
-    part1_pairs_arg = ",".join(part1_pairs)
-    cmd.append("--part1_pairs='%s'" % part1_pairs_arg)
+    if part1:
+        if not part1_func:
+            fail("part1_func is empty, but it is required because part1 is non-empty")
+        cmd.append("--part1_func='%s'" % part1_func)
+        part1_pairs = []
+        for in_file, out_file in part1.items():
+            part1_pairs.append("$(location %s):$(location %s)" % (in_file, out_file))
+            if in_file not in srcs:
+                srcs.append(in_file)
+            if out_file not in srcs:
+                srcs.append(out_file)
+        part1_pairs_arg = ",".join(part1_pairs)
+        cmd.append("--part1_pairs='%s'" % part1_pairs_arg)
 
-    part2_pairs = []
-    for in_file, out_file in part2.items():
-        part2_pairs.append("$(location %s):$(location %s)" % (in_file, out_file))
-        if in_file not in srcs:
-            srcs.append(in_file)
-        if out_file not in srcs:
-            srcs.append(out_file)
-    part2_pairs_arg = ",".join(part2_pairs)
-    cmd.append("--part2_pairs='%s'" % part2_pairs_arg)
+    if part2:
+        if not part2_func:
+            fail("part2_func is empty, but it is required because part2 is non-empty")
+        cmd.append("--part2_func='%s'" % part2_func)
+        part2_pairs = []
+        for in_file, out_file in part2.items():
+            part2_pairs.append("$(location %s):$(location %s)" % (in_file, out_file))
+            if in_file not in srcs:
+                srcs.append(in_file)
+            if out_file not in srcs:
+                srcs.append(out_file)
+        part2_pairs_arg = ",".join(part2_pairs)
+        cmd.append("--part2_pairs='%s'" % part2_pairs_arg)
 
     native.genrule(
         name = name + "_cc",

--- a/adventofcode/cc/tools/generate_benchmark/BUILD.bazel
+++ b/adventofcode/cc/tools/generate_benchmark/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "generate_benchmark_lib",
@@ -13,4 +13,11 @@ go_binary(
     name = "generate_benchmark",
     embed = [":generate_benchmark_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "generate_benchmark_test",
+    srcs = ["main_test.go"],
+    data = glob(["testdata/**"]) + [":generate_benchmark"],
+    deps = ["//runfiles"],
 )

--- a/adventofcode/cc/tools/generate_benchmark/dayXX_benchmark.cc.template
+++ b/adventofcode/cc/tools/generate_benchmark/dayXX_benchmark.cc.template
@@ -7,6 +7,7 @@
 #include "absl/strings/string_view.h"
 #include "benchmark/benchmark.h"
 
+{{ if (ne .Part1Func "") -}}
 static void BM_Part1(benchmark::State& state, absl::string_view input, absl::string_view want) {
   absl::StatusOr<std::string> got = {{.Namespace}}::{{.Part1Func}}(input);
   if (!got.ok()) {
@@ -23,8 +24,10 @@ static void BM_Part1(benchmark::State& state, absl::string_view input, absl::str
 }
 {{- range .Part1Pairs }}
 BENCHMARK_CAPTURE(BM_Part1, {{.File}}, R"({{.Input}})", adventofcode::cc::trim::TrimSpace(R"({{.Output}})"));
-{{- end}}
+{{- end }}
+{{- end }}
 
+{{ if (ne .Part2Func "") -}}
 static void BM_Part2(benchmark::State& state, absl::string_view input, absl::string_view want) {
   absl::StatusOr<std::string> got = {{.Namespace}}::{{.Part2Func}}(input);
   if (!got.ok()) {
@@ -41,4 +44,5 @@ static void BM_Part2(benchmark::State& state, absl::string_view input, absl::str
 }
 {{- range .Part2Pairs }}
 BENCHMARK_CAPTURE(BM_Part2, {{.File}}, R"({{.Input}})", adventofcode::cc::trim::TrimSpace(R"({{.Output}})"));
-{{- end}}
+{{- end }}
+{{- end }}

--- a/adventofcode/cc/tools/generate_benchmark/main_test.go
+++ b/adventofcode/cc/tools/generate_benchmark/main_test.go
@@ -1,0 +1,196 @@
+package main_test
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"go.saser.se/runfiles"
+)
+
+var (
+	binary  = runfiles.MustPath("adventofcode/cc/tools/generate_benchmark/generate_benchmark_/generate_benchmark")
+	inFile  = runfiles.MustPath("adventofcode/cc/tools/generate_benchmark/testdata/test.in")
+	outFile = runfiles.MustPath("adventofcode/cc/tools/generate_benchmark/testdata/test.out")
+)
+
+func TestGenerateBenchmark(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "OnlyHeader",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+			},
+		},
+		{
+			name: "Part1ExplicitlyEmpty",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "",
+			},
+		},
+		{
+			name: "Part2ExplicitlyEmpty",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "BothPartsExplicitlyEmpty",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "",
+				"-part2_func":  "",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "OnlyPart1",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "OnlyPart1_ExplicitlyEmptyPart2",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": inFile + ":" + outFile,
+				"-part2_func":  "",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "OnlyPart2",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "Part2",
+				"-part2_pairs": inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "OnlyPart2_ExplicitlyEmptyPart1",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "",
+				"-part2_func":  "Part2",
+				"-part2_pairs": inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "BothPart1AndPart2",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": inFile + ":" + outFile,
+				"-part2_func":  "Part2",
+				"-part2_pairs": inFile + ":" + outFile,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			for flag, value := range tt.flags {
+				args = append(args, flag+"="+value)
+			}
+			cmd := exec.Command(binary, args...)
+			var stderr, stdout strings.Builder
+			cmd.Stderr = &stderr
+			cmd.Stdout = &stdout
+			err := cmd.Run()
+			if err != nil {
+				lines := []string{
+					fmt.Sprintf("Error: %v", err),
+					fmt.Sprintf("Args: %q", args),
+					fmt.Sprintf("stderr:\n%s", stderr.String()),
+					fmt.Sprintf("stdout:\n%s", stdout.String()),
+				}
+				t.Error(strings.Join(lines, "\n"))
+			} else {
+				if stdout.Len() == 0 {
+					t.Errorf("Program exited successfully but there was no output. Args:\n%q", args)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateBenchmark_Error(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "NoHeaderFile",
+			flags: map[string]string{
+				"-header_file": "",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "Part1FuncButNoPairs",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "",
+			},
+		},
+		{
+			name: "Part1PairsButNoFunc",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "Part2FuncButNoPairs",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "Part2",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "Part2PairsButNoFunc",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "",
+				"-part2_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			for flag, value := range tt.flags {
+				args = append(args, flag+"="+value)
+			}
+			cmd := exec.Command(binary, args...)
+			var stderr, stdout strings.Builder
+			cmd.Stderr = &stderr
+			cmd.Stdout = &stdout
+			err := cmd.Run()
+			if err == nil { // if NO error
+				lines := []string{
+					"`generate_benchmark` unexpectedly ran successfully.",
+					fmt.Sprintf("Args: %q", args),
+					fmt.Sprintf("stderr:\n%s", stderr.String()),
+					fmt.Sprintf("stdout:\n%s", stdout.String()),
+				}
+				t.Error(strings.Join(lines, "\n"))
+			}
+		})
+	}
+}

--- a/adventofcode/cc/tools/generate_benchmark/testdata/test.in
+++ b/adventofcode/cc/tools/generate_benchmark/testdata/test.in
@@ -1,0 +1,1 @@
+This is some example input.

--- a/adventofcode/cc/tools/generate_benchmark/testdata/test.out
+++ b/adventofcode/cc/tools/generate_benchmark/testdata/test.out
@@ -1,0 +1,1 @@
+This is some example output.

--- a/adventofcode/cc/tools/generate_header/BUILD.bazel
+++ b/adventofcode/cc/tools/generate_header/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "generate_header_lib",
@@ -13,4 +13,11 @@ go_binary(
     name = "generate_header",
     embed = [":generate_header_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "generate_header_test",
+    srcs = ["main_test.go"],
+    data = [":generate_header"],
+    deps = ["//runfiles"],
 )

--- a/adventofcode/cc/tools/generate_header/main.go
+++ b/adventofcode/cc/tools/generate_header/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -21,8 +20,8 @@ func init() {
 var (
 	year  = flag.Int("year", 0, "The year. Must be 2015 or later.")
 	day   = flag.Int("day", 0, "The day. Must be in the range 1-25.")
-	part1 = flag.Bool("part1", true, "Whether to generate a function for part 1.")
-	part2 = flag.Bool("part2", true, "Whether to generate a function for part 2.")
+	part1 = flag.Bool("part1", false, "Whether to generate a function for part 1.")
+	part2 = flag.Bool("part2", false, "Whether to generate a function for part 2.")
 
 	output = flag.String("output", "", "Path to write the generated file to. Leaving this empty writes the file to stdout.")
 )
@@ -43,11 +42,8 @@ func errmain() error {
 	if *year < 2015 {
 		return fmt.Errorf("-year=%d must be 2015 or later", *year)
 	}
-	if *day < 1 || *day > 25 {
-		return fmt.Errorf("-day=%d must be in the range 1-25", *day)
-	}
-	if *day == 25 && *part2 {
-		return errors.New("-day=25 and -part2=true, but there's (generally) not a part 2 for day 25")
+	if d := *day; d < 1 || d > 25 {
+		return fmt.Errorf("-day=%d must be in the range 1-25", d)
 	}
 
 	args := templateArgs{

--- a/adventofcode/cc/tools/generate_header/main_test.go
+++ b/adventofcode/cc/tools/generate_header/main_test.go
@@ -1,0 +1,134 @@
+package main_test
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"go.saser.se/runfiles"
+)
+
+var binary = runfiles.MustPath("adventofcode/cc/tools/generate_header/generate_header_/generate_header")
+
+func TestGenerateHeader(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "NeitherPart",
+			flags: map[string]string{
+				"-year": "2023",
+				"-day":  "10",
+			},
+		},
+		{
+			name: "Part1",
+			flags: map[string]string{
+				"-year":  "2023",
+				"-day":   "10",
+				"-part1": "true",
+			},
+		},
+		{
+			name: "Part2",
+			flags: map[string]string{
+				"-year":  "2023",
+				"-day":   "10",
+				"-part2": "true",
+			},
+		},
+		{
+			name: "BothParts",
+			flags: map[string]string{
+				"-year":  "2023",
+				"-day":   "10",
+				"-part1": "true",
+				"-part2": "true",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			for flag, value := range tt.flags {
+				args = append(args, flag+"="+value)
+			}
+			cmd := exec.Command(binary, args...)
+			var stderr, stdout strings.Builder
+			cmd.Stderr = &stderr
+			cmd.Stdout = &stdout
+			err := cmd.Run()
+			if err != nil {
+				lines := []string{
+					fmt.Sprintf("Error: %v", err),
+					fmt.Sprintf("Args: %q", args),
+					fmt.Sprintf("stderr:\n%s", stderr.String()),
+					fmt.Sprintf("stdout:\n%s", stdout.String()),
+				}
+				t.Error(strings.Join(lines, "\n"))
+			} else {
+				if stdout.Len() == 0 {
+					t.Errorf("Program exited successfully but there was no output. Args:\n%q", args)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateHeader_Error(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "YearTooLow",
+			flags: map[string]string{
+				"-year": "1995",
+				"-day":  "10",
+			},
+		},
+		{
+			name: "DayTooLow",
+			flags: map[string]string{
+				"-year": "2023",
+				"-day":  "0",
+			},
+		},
+		{
+			name: "DayNegative",
+			flags: map[string]string{
+				"-year": "2023",
+				"-day":  "-10",
+			},
+		},
+		{
+			name: "DayTooHigh",
+			flags: map[string]string{
+				"-year": "2023",
+				"-day":  "26",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			for flag, value := range tt.flags {
+				args = append(args, flag+"="+value)
+			}
+			cmd := exec.Command(binary, args...)
+			var stderr, stdout strings.Builder
+			cmd.Stderr = &stderr
+			cmd.Stdout = &stdout
+			err := cmd.Run()
+			if err == nil { // if NO error
+				lines := []string{
+					"`generate_header` unexpectedly ran successfully.",
+					fmt.Sprintf("Args: %q", args),
+					fmt.Sprintf("stderr:\n%s", stderr.String()),
+					fmt.Sprintf("stdout:\n%s", stdout.String()),
+				}
+				t.Error(strings.Join(lines, "\n"))
+			}
+		})
+	}
+}

--- a/adventofcode/cc/tools/generate_test/BUILD.bazel
+++ b/adventofcode/cc/tools/generate_test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "generate_test_lib",
@@ -13,4 +13,11 @@ go_binary(
     name = "generate_test",
     embed = [":generate_test_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "generate_test_test",
+    srcs = ["main_test.go"],
+    data = glob(["testdata/**"]) + [":generate_test"],
+    deps = ["//runfiles"],
 )

--- a/adventofcode/cc/tools/generate_test/main.go
+++ b/adventofcode/cc/tools/generate_test/main.go
@@ -24,10 +24,10 @@ func init() {
 var (
 	headerFile    = flag.String("header_file", "", `The main header file in which the solver functions are declared. Should be in the format it will be included, e.g., "adventofcode/cc/year2022/day01.h".`)
 	namespaceFlag = flag.String("namespace", "", `The namespace in which the solver functions live. Should be double-colon-separated, e.g., "adventofcode::cc::year2022::day01". If left empty the value will be derived from the -header_file flag by replacing slashes with double colons and stripping the .h suffix, e.g., "adventofcode/cc/year2022/day01.h" => "adventofcode::cc::year2022::day01".`)
-	part1Func     = flag.String("part1_func", "Part1", "The name of the function solving part 1.")
-	part2Func     = flag.String("part2_func", "Part2", "The name of the function solving part 2.")
-	part1Pairs    = flag.String("part1_pairs", "", `Comma-separated list of file pairs of the form "name:in_file:out_file" containing problem inputs and corresponding expected outputs.`)
-	part2Pairs    = flag.String("part2_pairs", "", `Comma-separated list of file pairs of the form "name:in_file:out_file" containing problem inputs and corresponding expected outputs.`)
+	part1Func     = flag.String("part1_func", "", "The name of the function solving part 1. Required if -part1_pairs is non-empty.")
+	part2Func     = flag.String("part2_func", "", "The name of the function solving part 2. Required if -part2_pairs is non-empty.")
+	part1Pairs    = flag.String("part1_pairs", "", `Comma-separated list of file pairs of the form "name:in_file:out_file" containing problem inputs and corresponding expected outputs. Required if -part1_func is true.`)
+	part2Pairs    = flag.String("part2_pairs", "", `Comma-separated list of file pairs of the form "name:in_file:out_file" containing problem inputs and corresponding expected outputs. Required if -part2_func is true.`)
 
 	output = flag.String("output", "", "Path to write the generated file to. Leaving this empty writes the file to stdout.")
 )
@@ -64,64 +64,69 @@ func errmain() error {
 	}
 	args.Namespace = namespace
 
-	if *part1Func == "" {
-		return errors.New("-part1_func is required but was empty")
+	// The conditions in the if statements below evaluates to false if one of
+	// the flags is set but not the other.
+	if fn, pairs := *part1Func, *part1Pairs; (fn != "") != (pairs != "") {
+		return fmt.Errorf("-part1_func=%q and -part1_pairs=%q; either both or none must be set", fn, pairs)
 	}
 	args.Part1Func = *part1Func
-
-	if *part2Func == "" {
-		return errors.New("-part2_func is required but was empty")
+	if fn, pairs := *part2Func, *part2Pairs; (fn != "") != (pairs != "") {
+		return fmt.Errorf("-part2_func=%q and -part2_pairs=%q; either both or none must be set", fn, pairs)
 	}
 	args.Part2Func = *part2Func
 
-	if *part1Pairs == "" {
-		return errors.New("-part1_pairs is required but was empty")
-	}
-	for _, pair := range strings.Split(*part1Pairs, ",") {
-		parts := strings.Split(pair, ":")
-		if len(parts) != 3 {
-			return fmt.Errorf("-part1_pairs contains invalid element %q", pair)
+	if *part1Func != "" {
+		for _, pair := range strings.Split(*part1Pairs, ",") {
+			parts := strings.Split(pair, ":")
+			if len(parts) != 3 {
+				return fmt.Errorf("-part1_pairs contains invalid element %q", pair)
+			}
+			name := parts[0]
+			if name == "" {
+				return fmt.Errorf("-part1_pairs contains element with empty name: %q", pair)
+			}
+			in, out := parts[1], parts[2]
+			inData, err := os.ReadFile(in)
+			if err != nil {
+				return fmt.Errorf("-part1_pairs contained unreadable file: %v", err)
+			}
+			outData, err := os.ReadFile(out)
+			if err != nil {
+				return fmt.Errorf("-part1_pairs contained unreadable file: %v", err)
+			}
+			args.Part1Pairs = append(args.Part1Pairs, inOutPair{
+				Name: name,
+				In:   string(inData),
+				Out:  string(outData),
+			})
 		}
-		name := parts[0]
-		in, out := parts[1], parts[2]
-		inData, err := os.ReadFile(in)
-		if err != nil {
-			return fmt.Errorf("-part1_pairs contained unreadable file: %v", err)
-		}
-		outData, err := os.ReadFile(out)
-		if err != nil {
-			return fmt.Errorf("-part1_pairs contained unreadable file: %v", err)
-		}
-		args.Part1Pairs = append(args.Part1Pairs, inOutPair{
-			Name: name,
-			In:   string(inData),
-			Out:  string(outData),
-		})
 	}
 
-	if *part2Pairs == "" {
-		return errors.New("-part2_pairs is required but was empty")
-	}
-	for _, pair := range strings.Split(*part2Pairs, ",") {
-		parts := strings.Split(pair, ":")
-		if len(parts) != 3 {
-			return fmt.Errorf("-part2_pairs contains invalid element %q", pair)
+	if *part2Func != "" {
+		for _, pair := range strings.Split(*part2Pairs, ",") {
+			parts := strings.Split(pair, ":")
+			if len(parts) != 3 {
+				return fmt.Errorf("-part2_pairs contains invalid element %q", pair)
+			}
+			name := parts[0]
+			if name == "" {
+				return fmt.Errorf("-part2_pairs contains element with empty name: %q", pair)
+			}
+			in, out := parts[1], parts[2]
+			inData, err := os.ReadFile(in)
+			if err != nil {
+				return fmt.Errorf("-part2_pairs contained unreadable file: %v", err)
+			}
+			outData, err := os.ReadFile(out)
+			if err != nil {
+				return fmt.Errorf("-part2_pairs contained unreadable file: %v", err)
+			}
+			args.Part2Pairs = append(args.Part2Pairs, inOutPair{
+				Name: name,
+				In:   string(inData),
+				Out:  string(outData),
+			})
 		}
-		name := parts[0]
-		in, out := parts[1], parts[2]
-		inData, err := os.ReadFile(in)
-		if err != nil {
-			return fmt.Errorf("-part2_pairs contained unreadable file: %v", err)
-		}
-		outData, err := os.ReadFile(out)
-		if err != nil {
-			return fmt.Errorf("-part2_pairs contained unreadable file: %v", err)
-		}
-		args.Part2Pairs = append(args.Part2Pairs, inOutPair{
-			Name: name,
-			In:   string(inData),
-			Out:  string(outData),
-		})
 	}
 
 	klog.V(1).Infof("Template args: %+v", args)

--- a/adventofcode/cc/tools/generate_test/main_test.go
+++ b/adventofcode/cc/tools/generate_test/main_test.go
@@ -1,0 +1,212 @@
+package main_test
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"go.saser.se/runfiles"
+)
+
+var (
+	binary  = runfiles.MustPath("adventofcode/cc/tools/generate_test/generate_test_/generate_test")
+	inFile  = runfiles.MustPath("adventofcode/cc/tools/generate_test/testdata/test.in")
+	outFile = runfiles.MustPath("adventofcode/cc/tools/generate_test/testdata/test.out")
+)
+
+func TestGenerateTest(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "OnlyHeader",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+			},
+		},
+		{
+			name: "Part1ExplicitlyEmpty",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "",
+			},
+		},
+		{
+			name: "Part2ExplicitlyEmpty",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "BothPartsExplicitlyEmpty",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "",
+				"-part2_func":  "",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "OnlyPart1",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "OnlyPart1_ExplicitlyEmptyPart2",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+				"-part2_func":  "",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "OnlyPart2",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "Part2",
+				"-part2_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "OnlyPart2_ExplicitlyEmptyPart1",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "",
+				"-part2_func":  "Part2",
+				"-part2_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "BothPart1AndPart2",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+				"-part2_func":  "Part2",
+				"-part2_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			for flag, value := range tt.flags {
+				args = append(args, flag+"="+value)
+			}
+			cmd := exec.Command(binary, args...)
+			var stderr, stdout strings.Builder
+			cmd.Stderr = &stderr
+			cmd.Stdout = &stdout
+			err := cmd.Run()
+			if err != nil {
+				lines := []string{
+					fmt.Sprintf("Error: %v", err),
+					fmt.Sprintf("Args: %q", args),
+					fmt.Sprintf("stderr:\n%s", stderr.String()),
+					fmt.Sprintf("stdout:\n%s", stdout.String()),
+				}
+				t.Error(strings.Join(lines, "\n"))
+			} else {
+				if stdout.Len() == 0 {
+					t.Errorf("Program exited successfully but there was no output. Args:\n%q", args)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateTest_Error(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "NoHeaderFile",
+			flags: map[string]string{
+				"-header_file": "",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "Part1FuncButNoPairs",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "",
+			},
+		},
+		{
+			name: "Part1PairsButNoFunc",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "",
+				"-part1_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "Part2FuncButNoPairs",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "Part2",
+				"-part2_pairs": "",
+			},
+		},
+		{
+			name: "Part2PairsButNoFunc",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part2_func":  "",
+				"-part2_pairs": "test:" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "PairWithoutName",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": "" + inFile + ":" + outFile,
+			},
+		},
+		{
+			name: "PairWithEmptyName",
+			flags: map[string]string{
+				"-header_file": "adventofcode/cc/year2050/day01.h",
+				"-part1_func":  "Part1",
+				"-part1_pairs": ":" + inFile + ":" + outFile,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			for flag, value := range tt.flags {
+				args = append(args, flag+"="+value)
+			}
+			cmd := exec.Command(binary, args...)
+			var stderr, stdout strings.Builder
+			cmd.Stderr = &stderr
+			cmd.Stdout = &stdout
+			err := cmd.Run()
+			if err == nil { // if NO error
+				lines := []string{
+					"`generate_test` unexpectedly ran successfully.",
+					fmt.Sprintf("Args: %q", args),
+					fmt.Sprintf("stderr:\n%s", stderr.String()),
+					fmt.Sprintf("stdout:\n%s", stdout.String()),
+				}
+				t.Error(strings.Join(lines, "\n"))
+			}
+		})
+	}
+}

--- a/adventofcode/cc/tools/generate_test/testdata/test.in
+++ b/adventofcode/cc/tools/generate_test/testdata/test.in
@@ -1,0 +1,1 @@
+This is some example input.

--- a/adventofcode/cc/tools/generate_test/testdata/test.out
+++ b/adventofcode/cc/tools/generate_test/testdata/test.out
@@ -1,0 +1,1 @@
+This is some example output.


### PR DESCRIPTION
I ran into some trouble when I created a solution for day 25, because the code generation tools were fighting me when I wanted to generate only part 1. I figured the tools shouldn't really care about this: they should be "dumb" and only generate exactly what I tell them to generate.

Therefore, I more or less removed all the logic around checking that both part 1 and part 2 are always present, that day 25 + part 2 is an invalid combination, etc. To exercise this I also wrote some tests that invoke the code generation tools as regular binaries.