### PR TITLE
adventofcode/cc/geometry: first iteration of geometry library with a 2D `Pos` type.

### DIFF
--- a/adventofcode/cc/geometry/BUILD.bazel
+++ b/adventofcode/cc/geometry/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//adventofcode/cc:__subpackages__"])
+
+cc_library(
+    name = "pos",
+    srcs = ["pos.cc"],
+    hdrs = ["pos.h"],
+    deps = ["@com_google_absl//absl/strings:str_format"],
+)
+
+cc_test(
+    name = "pos_test",
+    srcs = ["pos_test.cc"],
+    deps = [
+        ":pos",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/adventofcode/cc/geometry/pos.cc
+++ b/adventofcode/cc/geometry/pos.cc
@@ -1,0 +1,15 @@
+#include "adventofcode/cc/geometry/pos.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace adventofcode {
+namespace cc {
+namespace geometry {
+int64_t Pos::Distance() const { return Distance(Pos{.x = 0, .y = 0}); }
+int64_t Pos::Distance(const Pos& to) const {
+  return std::abs(x - to.x) + std::abs(y - to.y);
+}
+}  // namespace geometry
+}  // namespace cc
+}  // namespace adventofcode

--- a/adventofcode/cc/geometry/pos.h
+++ b/adventofcode/cc/geometry/pos.h
@@ -1,0 +1,77 @@
+#ifndef ADVENTOFCODE_CC_GEOMETRY_POS_H
+#define ADVENTOFCODE_CC_GEOMETRY_POS_H
+
+#include <cstdint>
+#include <ostream>
+
+#include "absl/strings/str_format.h"
+
+namespace adventofcode {
+namespace cc {
+namespace geometry {
+// Pos represents a point with integral coordinates in a 2D plane.
+struct Pos {
+  int64_t x, y;
+
+  // Distance returns the Manhattan distance between this Pos and another Pos.
+  // Calling Distance with no argument returns the Manhattan distance to (0, 0).
+  // I have not bothered to deal with edge cases like underflows or the distance
+  // being more than 2^63-1.
+  int64_t Distance() const;
+  int64_t Distance(const Pos& to) const;
+
+  // AbslStringify implements string formatting for integration with Abseil
+  // libraries.
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, const Pos& p) {
+    absl::Format(&sink, "(%d,%d)", p.x, p.y);
+  }
+
+  // GoogleTest _should_ be able to make use of AbslStringify, but for some
+  // reason it doesn't. However, it does pick up the PrintTo function, as
+  // explained in
+  // https://github.com/google/googletest/blob/3288c4deae0710464a0fd21316084c408798b960/docs/advanced.md#teaching-googletest-how-to-print-your-values.
+  // This implementation of PrintTo simply calls out to the AbslStringify
+  // function, so that they share the implementation.
+  friend void PrintTo(const Pos& p, std::ostream* os) { AbslStringify(*os, p); }
+
+  // AbslHashValue implements hashing for use with Abseil's hash-based
+  // containers, like absl::flat_hash_{map,set}.
+  template <typename H>
+  friend H AbslHashValue(H h, const Pos& p) {
+    return H::combine(std::move(h), p.x, p.y);
+  }
+
+  friend bool operator==(const Pos& lhs, const Pos& rhs) {
+    return lhs.x == rhs.x && lhs.y == rhs.y;
+  }
+  friend bool operator!=(const Pos& lhs, const Pos& rhs) {
+    return !(lhs == rhs);
+  }
+
+  // Arithmetic operators taken from https://stackoverflow.com/a/52377719.
+  Pos& operator+=(const Pos& rhs) {
+    x += rhs.x;
+    y += rhs.y;
+    return *this;
+  }
+  friend Pos operator+(Pos lhs, const Pos& rhs) {
+    lhs += rhs;
+    return lhs;
+  }
+
+  Pos& operator-=(const Pos& rhs) {
+    x -= rhs.x;
+    y -= rhs.y;
+    return *this;
+  }
+  friend Pos operator-(Pos lhs, const Pos& rhs) {
+    lhs -= rhs;
+    return lhs;
+  }
+};
+}  // namespace geometry
+}  // namespace cc
+}  // namespace adventofcode
+
+#endif

--- a/adventofcode/cc/geometry/pos_test.cc
+++ b/adventofcode/cc/geometry/pos_test.cc
@@ -1,0 +1,77 @@
+#include "adventofcode/cc/geometry/pos.h"
+
+#include "absl/hash/hash_testing.h"
+#include "absl/strings/str_format.h"
+#include "gtest/gtest.h"
+
+namespace adventofcode {
+namespace cc {
+namespace geometry {
+TEST(PosTest, Distance) {
+  EXPECT_EQ((Pos{.x = 0, .y = 0}).Distance(), 0);
+  EXPECT_EQ((Pos{.x = +1, .y = 0}).Distance(), 1);
+  EXPECT_EQ((Pos{.x = -1, .y = 0}).Distance(), 1);
+  EXPECT_EQ((Pos{.x = +1, .y = +1}).Distance(), 2);
+  EXPECT_EQ((Pos{.x = -1, .y = +1}).Distance(), 2);
+  EXPECT_EQ((Pos{.x = +1, .y = -1}).Distance(), 2);
+  EXPECT_EQ((Pos{.x = -1, .y = -1}).Distance(), 2);
+}
+
+TEST(PosTest, DistanceTo) {
+  EXPECT_EQ((Pos{.x = 0, .y = 0}).Distance(Pos{.x = 0, .y = 0}), 0);
+  EXPECT_EQ((Pos{.x = +1, .y = 0}).Distance(Pos{.x = +1, .y = 0}), 0);
+  EXPECT_EQ((Pos{.x = -1, .y = 0}).Distance(Pos{.x = +1, .y = 0}), 2);
+  EXPECT_EQ((Pos{.x = -1, .y = -1}).Distance(Pos{.x = +1, .y = +1}), 4);
+}
+
+TEST(PosTest, AbslStringify) {
+  // Using absl::StrFormat here is my lazy version of calling the AbslStringify
+  // function.
+  EXPECT_EQ(absl::StrFormat("%v", Pos{.x = +1, .y = +1}), "(1,1)");
+  EXPECT_EQ(absl::StrFormat("%v", Pos{.x = +1, .y = -1}), "(1,-1)");
+  EXPECT_EQ(absl::StrFormat("%v", Pos{.x = -1, .y = +1}), "(-1,1)");
+  EXPECT_EQ(absl::StrFormat("%v", Pos{.x = -1, .y = -1}), "(-1,-1)");
+}
+
+TEST(PosTest, AbslHashValue) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+      Pos{.x = 0, .y = 0},
+      Pos{.x = +1, .y = +1},
+      Pos{.x = +1, .y = -1},
+      Pos{.x = -1, .y = +1},
+      Pos{.x = -1, .y = -1},
+      Pos{.x = -123, .y = +456},
+  }));
+}
+
+TEST(PosTest, Addition) {
+  Pos a{.x = 1, .y = 2};
+  Pos b{.x = 10, .y = 10};
+  Pos want{.x = 11, .y = 12};
+  EXPECT_EQ(a + b, want);
+  EXPECT_EQ(b + a, want);
+  Pos a2 = a;
+  a2 += b;
+  EXPECT_EQ(a2, want);
+  Pos b2 = b;
+  b2 += a;
+  EXPECT_EQ(b2, want);
+}
+
+TEST(PosTest, Subtraction) {
+  Pos a{.x = 1, .y = 2};
+  Pos b{.x = 10, .y = 10};
+  Pos amb{.x = -9, .y = -8};
+  Pos bma{.x = 9, .y = 8};
+  EXPECT_EQ(a - b, amb);
+  EXPECT_EQ(b - a, bma);
+  Pos a2 = a;
+  a2 -= b;
+  EXPECT_EQ(a2, amb);
+  Pos b2 = b;
+  b2 -= a;
+  EXPECT_EQ(b2, bma);
+}
+}  // namespace geometry
+}  // namespace cc
+}  // namespace adventofcode


### PR DESCRIPTION
This `Pos` type implements some basic useful stuff:
- `+`/`-` operators
- string formatting
- hashing
- Manhattan distance

This will certainly be useful enough for most use cases of 2D positions in Advent of Code problems.